### PR TITLE
Fixed #439 and #435

### DIFF
--- a/homematicip/base/functionalChannels.py
+++ b/homematicip/base/functionalChannels.py
@@ -1022,8 +1022,8 @@ class RainDetectionChannel(FunctionalChannel):
 class TemperaturDifferenceSensor2Channel(FunctionalChannel):
     """ this is the representative of the TEMPERATURE_SENSOR_2_EXTERNAL_DELTA_CHANNEL channel """
 
-    def __init__(self, connection):
-        super().__init__(connection)
+    def __init__(self):
+        super().__init__()
         #:float:
         self.temperatureExternalDelta = 0.0
         #:float:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -13,6 +13,13 @@ from homematicip_demo.helper import (
     no_ssl_verification,
 )
 
+from homematicip.class_maps import TYPE_FUNCTIONALCHANNEL_MAP
+
+def test_getTypeFunctionalChannelMap(fake_home: Home):
+    for channelType in TYPE_FUNCTIONALCHANNEL_MAP.keys():
+        fc = TYPE_FUNCTIONALCHANNEL_MAP[channelType]()
+        assert fc != None
+
 
 def test_room_control_device(fake_home: Home):
     d = fake_home.search_device_by_id("3014F711000BBBB000000000")


### PR DESCRIPTION
Fixes Errormessage
There is no class for functionalChannel 'TEMPERATURE_SENSOR_2_EXTERNAL_DELTA_CHANNEL' yet

when using Sensor HmIP-STE2-PCB.
