### PR TITLE
Create a custom throttling error class type. 

### DIFF
--- a/homematicip/aio/connection.py
+++ b/homematicip/aio/connection.py
@@ -14,6 +14,7 @@ from homematicip.base.base_connection import (
     ATTR_CLIENT_AUTH,
     BaseConnection,
     HmipConnectionError,
+    HmipThrottlingError,
     HmipWrongHttpStatusError,
 )
 
@@ -93,6 +94,8 @@ class AsyncConnection(BaseConnection):
                         else:
                             ret = True
                         return ret
+                    elif result.status == 429:
+                        raise HmipThrottlingError
                     else:
                         raise HmipWrongHttpStatusError(result.status)
             except (asyncio.TimeoutError, aiohttp.ClientConnectionError):

--- a/homematicip/base/base_connection.py
+++ b/homematicip/base/base_connection.py
@@ -23,6 +23,10 @@ class HmipServerCloseError(HmipConnectionError):
     pass
 
 
+class HmipThrottlingError(HmipConnectionError):
+    pass
+
+
 class BaseConnection:
     """Base connection class.
 


### PR DESCRIPTION
I believe throttling errors are bound to affect anyone who uses the library. This change introduces a custom throttling error type that is thrown whenever one of the REST calls returns a 429 status code. 

Currently the code simply crashes at unrelated location and is likely confusing for any users. By throwing a custom error type, client code can more easily react to the throttling error, by avoiding any retries for the requested 15 mins.

I should note that is only a small step in the direction of proper error handling, as the `_restcall ` method returns an empty string if any errors are encountered with the exception of timeout error.