### PR TITLE
Use SPDX license expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ keywords = ["homematicip cloud","homematicip"]
 dynamic = [
     "version"
 ]
-license = {file = "LICENSE.txt"}
+license = {text = "GPL-3.0-or-later"}
 
 [project.urls]
 Homepage = "https://github.com/hahn-th/homematicip-rest-api"


### PR DESCRIPTION
Use the SPDX license identifier as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/GPL-3.0-or-later.html

https://github.com/hahn-th/homematicip-rest-api/blob/5f26e1daa00156f3391f04affc3a35bc193035e7/LICENSE.txt#L637-L640