### PR TITLE
Add HMIP-WTH-1 to implemented devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ A few examples:
 - [ ] HMIP-WRCR (Wall-mount Remote Control - Rotary)
 - [ ] HMIP-WT (Wall Mounted Thermostat without adjusting wheel) #probably only prototype for WTH-B and was not released
 - [x] HMIP-WTH (Wall Mounted Thermostat Pro with Display)
-- [ ] HMIP-WTH-1 (Wall Mounted Thermostat Pro with Display _Newest Version_ - successor of WTH-2 - really)
+- [x] HMIP-WTH-1 (Wall Mounted Thermostat Pro with Display _Newest Version_ - successor of WTH-2 - really)
 - [x] HMIP-WTH-2 (Wall Mounted Thermostat Pro with Display)
 - [x] HMIP-WTH-B (Wall Mounted Thermostat basic without adjusting wheel)
 - [ ] HMIP-WTH-B-2 (Wall Mounted Thermostat basic without adjusting wheel) New Version


### PR DESCRIPTION
Verified in Home Assistant that the HMIP-WTH-1 is also supported.

<img width="1041" height="353" alt="293252279-675f21bf-0ff2-4e67-b2d0-44fb168e5a77" src="https://github.com/user-attachments/assets/965ba226-db14-4172-bac3-7f335733e4f4" />


