### PR TITLE
Add support for HmIP-WGT glass thermostat types and channels

### DIFF
--- a/homematicip_demo/json_data/home.json
+++ b/homematicip_demo/json_data/home.json
@@ -15475,8 +15475,231 @@
       "serializedGlobalTradeItemNumber": "3014F7110000000ELVSHSMSI",
       "type": "SOIL_MOISTURE_SENSOR_INTERFACE",
       "updateState": "UP_TO_DATE"
+    },
+    "3014F71100000000000000WGT": {
+      "availableFirmwareVersion": "1.0.14",
+      "connectionType": "HMIP_RF",
+      "deviceArchetype": "HMIP",
+      "firmwareVersion": "1.0.14",
+      "firmwareVersionInteger": 65550,
+      "functionalChannels": {
+        "0": {
+          "altitude": null,
+          "busConfigMismatch": null,
+          "coProFaulty": false,
+          "coProRestartNeeded": false,
+          "coProUpdateFailure": false,
+          "configPending": false,
+          "controlsMountingOrientation": null,
+          "daliBusState": null,
+          "dataDecodingFailedError": null,
+          "defaultLinkedGroup": [],
+          "deviceAliveSignalEnabled": null,
+          "deviceCanBusError": null,
+          "deviceCommunicationError": null,
+          "deviceDriveError": null,
+          "deviceDriveModeError": null,
+          "deviceId": "3014F71100000000000000WGT",
+          "deviceOperationMode": null,
+          "deviceOverheated": false,
+          "deviceOverloaded": false,
+          "devicePowerFailureDetected": false,
+          "deviceUndervoltage": false,
+          "displayContrast": null,
+          "displayMode": null,
+          "displayMountingOrientation": null,
+          "dutyCycle": false,
+          "fanControlMode": null,
+          "frostProtectionError": null,
+          "frostProtectionErrorAcknowledged": null,
+          "functionalChannelType": "DEVICE_OPERATIONLOCK",
+          "groupIndex": 0,
+          "groups": [
+            "00000000-0000-0000-0000-000000000011"
+          ],
+          "index": 0,
+          "inputLayoutMode": null,
+          "invertedDisplayColors": null,
+          "label": "",
+          "lockJammed": null,
+          "lowBat": null,
+          "mountingModuleError": null,
+          "mountingOrientation": null,
+          "multicastRoutingEnabled": false,
+          "noDataFromLinkyError": null,
+          "notRechargeableBattery": null,
+          "operationDays": null,
+          "operationLockActive": false,
+          "particulateMatterSensorCommunicationError": null,
+          "particulateMatterSensorError": null,
+          "powerShortCircuit": null,
+          "profilePeriodLimitReached": null,
+          "routerModuleEnabled": false,
+          "routerModuleSupported": false,
+          "rssiDeviceValue": -70,
+          "rssiPeerValue": -67,
+          "sensorCommunicationError": null,
+          "sensorError": null,
+          "shortCircuitDataLine": null,
+          "supportedOptionalFeatures": {
+            "IFeatureDeviceIdentify": true,
+            "IFeatureDeviceMountingModuleError": true,
+            "IFeatureDeviceOverloaded": true,
+            "IFeatureProfilePeriodLimit": true,
+            "IFeatureRssiValue": true,
+            "IOptionalFeatureDeviceSwitchChannelMode": true,
+            "IOptionalFeatureDutyCycle": true
+          },
+          "switchChannelMode": "FLOOR_HEATING",
+          "temperatureHumiditySensorCommunicationError": null,
+          "temperatureHumiditySensorError": null,
+          "temperatureOutOfRange": false,
+          "ticVersionError": null,
+          "unreach": false,
+          "valveFlowError": null,
+          "valveWaterError": null
+        },
+        "1": {
+          "channelRole": "KEY_OR_SWITCH_FOR_GROUP",
+          "deviceId": "3014F71100000000000000WGT",
+          "functionalChannelType": "INPUT_QUICK_ACTION_DISPLAY_CHANNEL",
+          "groupIndex": 1,
+          "groups": [],
+          "index": 1,
+          "label": "",
+          "supportedOptionalFeatures": {
+            "IFeatureLightGroupSensorChannel": true,
+            "IFeatureShadingGroupSensorChannel": true
+          }
+        },
+        "2": {
+          "channelRole": "DIMMING_ACTUATOR",
+          "deviceId": "3014F71100000000000000WGT",
+          "dimLevel": 1.0,
+          "functionalChannelType": "BACKLIGHT_CHANNEL",
+          "groupIndex": 2,
+          "groups": [],
+          "index": 2,
+          "label": "Beleuchtung Thermostat EG Wohnzimmer",
+          "on": true,
+          "powerUpDimLevel": 0.75,
+          "powerUpSwitchState": "PERMANENT_OFF",
+          "profileMode": "AUTOMATIC",
+          "supportedOptionalFeatures": {
+            "IFeatureLightProfileActuatorChannel": true
+          },
+          "switchVisualization": "LIGHT",
+          "userDesiredProfileMode": "AUTOMATIC"
+        },
+        "3": {
+          "actualTemperature": 19.2,
+          "channelRole": "WALL_MOUNTED_THERMOSTAT",
+          "deviceId": "3014F71100000000000000WGT",
+          "display": "ACTUAL",
+          "functionalChannelType": "WALL_MOUNTED_THERMOSTAT_PRO_CHANNEL",
+          "groupIndex": 3,
+          "groups": [
+            "00000000-0000-0000-0000-000000000012"
+          ],
+          "humidity": 47,
+          "index": 3,
+          "label": "Thermostat EG Wohnzimmer ",
+          "setPointTemperature": 22.0,
+          "supportedOptionalFeatures": {
+            "IOptionalFeatureClimateControlDisplayHumidityOnlySupported": true,
+            "IOptionalFeatureThermostatCoolingSupported": true
+          },
+          "temperatureOffset": 0.0,
+          "vaporAmount": 7.732132100840245
+        },
+        "4": {
+          "climateControlType": "PWM_CONTROL",
+          "deviceId": "3014F71100000000000000WGT",
+          "frostProtectionTemperature": 8.0,
+          "functionalChannelType": "INTERNAL_SWITCH_CHANNEL",
+          "groupIndex": 3,
+          "groups": [],
+          "heatingValveType": "NORMALLY_CLOSE",
+          "index": 4,
+          "internalSwitchOutputEnabled": true,
+          "label": "Thermostat EG Wohnzimmer ",
+          "supportedOptionalFeatures": {
+            "IOptionalFeatureClimateControlType": true,
+            "IOptionalFeatureFloorHeatingSpecificGroupSupported": true
+          },
+          "valvePosition": 1.0,
+          "valveProtectionDuration": 5,
+          "valveProtectionSwitchingInterval": 14
+        },
+        "5": {
+          "channelRole": null,
+          "deviceId": "3014F71100000000000000WGT",
+          "functionalChannelType": "SWITCH_CHANNEL",
+          "groupIndex": 0,
+          "groups": [],
+          "index": 5,
+          "internalLinkConfiguration": null,
+          "label": "",
+          "on": true,
+          "powerUpSwitchState": "PERMANENT_OFF",
+          "profileMode": "AUTOMATIC",
+          "supportedOptionalFeatures": {
+            "IOptionalFeaturePowerUpSwitchState": true
+          },
+          "switchVisualization": null,
+          "userDesiredProfileMode": "AUTOMATIC"
+        },
+        "6": {
+          "deviceId": "3014F71100000000000000WGT",
+          "functionalChannelType": "HEAT_DEMAND_CHANNEL",
+          "groupIndex": 0,
+          "groups": [],
+          "index": 6,
+          "label": ""
+        },
+        "7": {
+          "deviceId": "3014F71100000000000000WGT",
+          "functionalChannelType": "DEHUMIDIFIER_DEMAND_CHANNEL",
+          "groupIndex": 0,
+          "groups": [],
+          "index": 7,
+          "label": ""
+        },
+        "8": {
+          "deviceId": "3014F71100000000000000WGT",
+          "functionalChannelType": "CHANGE_OVER_CHANNEL",
+          "groupIndex": 0,
+          "groups": [],
+          "index": 8,
+          "label": ""
+        }
+      },
+      "homeId": "00000000-0000-0000-0000-000000000001",
+      "id": "3014F71100000000000000WGT",
+      "label": "Thermostat EG Wohnzimmer ",
+      "lastStatusUpdate": 1768212833591,
+      "liveUpdateState": "LIVE_UPDATE_NOT_SUPPORTED",
+      "manuallyUpdateForced": false,
+      "manufacturerCode": 1,
+      "measuredAttributes": {
+        "3": {
+          "actualTemperature": true,
+          "humidity": true,
+          "setPointTemperature": true
+        },
+        "4": {
+          "valvePosition": true
+        }
+      },
+      "modelId": 556,
+      "modelType": "HmIP-WGT",
+      "oem": "eQ-3",
+      "permanentlyReachable": true,
+      "serializedGlobalTradeItemNumber": "3014F71100000000000000WGT",
+      "type": "WALL_MOUNTED_GLASS_THERMOSTAT",
+      "updateState": "UP_TO_DATE"
     }
-  },
+},
   "groups": {
     "00000000-0000-0000-0000-0000000000EN": {
       "channels": [

--- a/src/homematicip/base/enums.py
+++ b/src/homematicip/base/enums.py
@@ -196,12 +196,14 @@ class ClientType(AutoNameEnum):
     APP = auto()
     C2C = auto()
     SMART_WATCH = auto()
+    PLUGIN = auto()
 
 
 class DeviceType(AutoNameEnum):
     DEVICE = auto()
     BASE_DEVICE = auto()
     EXTERNAL = auto()
+    PLUGIN_EXTERNAL = auto()
     ACCELERATION_SENSOR = auto()
     ACCESS_POINT = auto()
     ALARM_SIREN_INDOOR = auto()
@@ -290,6 +292,7 @@ class DeviceType(AutoNameEnum):
     TILT_VIBRATION_SENSOR_COMPACT = auto()
     TORMATIC_MODULE = auto()
     WALL_MOUNTED_KEY_PAD = auto()
+    WALL_MOUNTED_GLASS_THERMOSTAT = auto()
     WALL_MOUNTED_THERMOSTAT_BASIC_HUMIDITY = auto()
     WALL_MOUNTED_THERMOSTAT_PRO = auto()
     WALL_MOUNTED_GARAGE_DOOR_CONTROLLER = auto()
@@ -355,6 +358,7 @@ class GroupType(AutoNameEnum):
     SMOKE_ALARM_DETECTION_RULE = auto()
     SWITCHING = auto()
     SWITCHING_PROFILE = auto()
+    DEMAND_CONTROLLED_VENTILATION_GROUP = auto()
 
 
 class SecurityEventType(AutoNameEnum):
@@ -450,6 +454,7 @@ class FunctionalChannelType(AutoNameEnum):
     ALARM_SIREN_CHANNEL = auto()
     ANALOG_OUTPUT_CHANNEL = auto()
     ANALOG_ROOM_CONTROL_CHANNEL = auto()
+    BACKLIGHT_CHANNEL = auto()
     BLIND_CHANNEL = auto()
     CHANGE_OVER_CHANNEL = auto()
     CARBON_DIOXIDE_SENSOR_CHANNEL = auto()
@@ -473,6 +478,7 @@ class FunctionalChannelType(AutoNameEnum):
     DOOR_LOCK_CHANNEL = auto()
     DOOR_LOCK_SENSOR_CHANNEL = auto()
     EXTERNAL_BASE_CHANNEL = auto()
+    EXTERNAL_SWITCH_CHANNEL = auto()
     EXTERNAL_UNIVERSAL_LIGHT_CHANNEL = auto()
     ENERGY_SENSORS_INTERFACE_CHANNEL = auto()
     FLOOR_TERMINAL_BLOCK_CHANNEL = auto()
@@ -483,6 +489,7 @@ class FunctionalChannelType(AutoNameEnum):
     HEATING_THERMOSTAT_CHANNEL = auto()
     IMPULSE_OUTPUT_CHANNEL = auto()
     INTERNAL_SWITCH_CHANNEL = auto()
+    INPUT_QUICK_ACTION_DISPLAY_CHANNEL = auto()
     LIGHT_SENSOR_CHANNEL = auto()
     MAINS_FAILURE_CHANNEL = auto()
     MOTION_DETECTION_CHANNEL = auto()
@@ -634,6 +641,7 @@ class AlarmSignalType(AutoNameEnum):
 
 class ConnectionType(AutoNameEnum):
     EXTERNAL = auto()
+    PLUGIN_EXTERNAL = auto()
     HMIP_RF = auto()
     HMIP_WIRED = auto()
     HMIP_LAN = auto()
@@ -642,6 +650,7 @@ class ConnectionType(AutoNameEnum):
 
 class DeviceArchetype(AutoNameEnum):
     EXTERNAL = auto()
+    PLUGIN_EXTERNAL = auto()
     HMIP = auto()
     PLUGIN = auto()
 

--- a/src/homematicip/base/functionalChannels.py
+++ b/src/homematicip/base/functionalChannels.py
@@ -215,6 +215,17 @@ class SwitchChannel(FunctionalChannel):
         return await self.async_set_switch_state(False)
 
 
+class ExternalSwitchChannel(SwitchChannel):
+    """this is the representative of the EXTERNAL_SWITCH_CHANNEL channel"""
+
+    def from_json(self, js, groups: Iterable[Group]):
+        FunctionalChannel.from_json(self, js, groups)
+        self.on = js.get("on", False)
+        self.powerUpSwitchState = js.get("powerUpSwitchState", "")
+        self.profileMode = js.get("profileMode")
+        self.userDesiredProfileMode = js.get("userDesiredProfileMode")
+
+
 class AccelerationSensorChannel(FunctionalChannel):
     """this is the representative of the ACCELERATION_SENSOR_CHANNEL channel"""
 

--- a/src/homematicip/class_maps.py
+++ b/src/homematicip/class_maps.py
@@ -9,6 +9,7 @@ TYPE_CLASS_MAP = {
     DeviceType.DEVICE: Device,
     DeviceType.BASE_DEVICE: BaseDevice,
     DeviceType.EXTERNAL: ExternalDevice,
+    DeviceType.PLUGIN_EXTERNAL: ExternalDevice,
     DeviceType.ACCELERATION_SENSOR: AccelerationSensor,
     DeviceType.ACCESS_POINT: HomeControlUnit,
     DeviceType.ALARM_SIREN_INDOOR: AlarmSirenIndoor,
@@ -97,6 +98,7 @@ TYPE_CLASS_MAP = {
     DeviceType.TILT_VIBRATION_SENSOR_COMPACT: TiltVibrationSensor,
     DeviceType.TORMATIC_MODULE: GarageDoorModuleTormatic,
     DeviceType.WALL_MOUNTED_KEY_PAD: WallMountedKeyPad,
+    DeviceType.WALL_MOUNTED_GLASS_THERMOSTAT: WallMountedThermostatPro,
     DeviceType.WALL_MOUNTED_GARAGE_DOOR_CONTROLLER: WallMountedGarageDoorController,
     DeviceType.WALL_MOUNTED_THERMOSTAT_PRO: WallMountedThermostatPro,
     DeviceType.WALL_MOUNTED_THERMOSTAT_BASIC_HUMIDITY: WallMountedThermostatBasicHumidity,
@@ -160,6 +162,7 @@ TYPE_GROUP_MAP = {
     GroupType.SHUTTER_WIND_PROTECTION_RULE: ShutterWindProtectionRule,
     GroupType.SMOKE_ALARM_DETECTION_RULE: SmokeAlarmDetectionRule,
     GroupType.SWITCHING_PROFILE: SwitchingProfileGroup,
+    GroupType.DEMAND_CONTROLLED_VENTILATION_GROUP: Group,
     GroupType.SWITCHING: SwitchingGroup,
 }
 
@@ -199,6 +202,7 @@ TYPE_FUNCTIONALCHANNEL_MAP = {
     FunctionalChannelType.ALARM_SIREN_CHANNEL: AlarmSirenChannel,
     FunctionalChannelType.ANALOG_OUTPUT_CHANNEL: AnalogOutputChannel,
     FunctionalChannelType.ANALOG_ROOM_CONTROL_CHANNEL: AnalogRoomControlChannel,
+    FunctionalChannelType.BACKLIGHT_CHANNEL: DimmerChannel,
     FunctionalChannelType.BLIND_CHANNEL: BlindChannel,
     FunctionalChannelType.CARBON_DIOXIDE_SENSOR_CHANNEL: CarbonDioxideSensorChannel,
     FunctionalChannelType.CHANGE_OVER_CHANNEL: ChangeOverChannel,
@@ -222,6 +226,7 @@ TYPE_FUNCTIONALCHANNEL_MAP = {
     FunctionalChannelType.DOOR_LOCK_CHANNEL: DoorLockChannel,
     FunctionalChannelType.DOOR_LOCK_SENSOR_CHANNEL: DoorLockSensorChannel,
     FunctionalChannelType.EXTERNAL_BASE_CHANNEL: ExternalBaseChannel,
+    FunctionalChannelType.EXTERNAL_SWITCH_CHANNEL: ExternalSwitchChannel,
     FunctionalChannelType.EXTERNAL_UNIVERSAL_LIGHT_CHANNEL: ExternalUniversalLightChannel,
     FunctionalChannelType.ENERGY_SENSORS_INTERFACE_CHANNEL: EnergySensorInterfaceChannel,
     FunctionalChannelType.FLOOR_TERMINAL_BLOCK_CHANNEL: FloorTeminalBlockChannel,
@@ -232,6 +237,7 @@ TYPE_FUNCTIONALCHANNEL_MAP = {
     FunctionalChannelType.HEATING_THERMOSTAT_CHANNEL: HeatingThermostatChannel,
     FunctionalChannelType.IMPULSE_OUTPUT_CHANNEL: ImpulseOutputChannel,
     FunctionalChannelType.INTERNAL_SWITCH_CHANNEL: InternalSwitchChannel,
+    FunctionalChannelType.INPUT_QUICK_ACTION_DISPLAY_CHANNEL: FunctionalChannel,
     FunctionalChannelType.LIGHT_SENSOR_CHANNEL: LightSensorChannel,
     FunctionalChannelType.MAINS_FAILURE_CHANNEL: MainsFailureChannel,
     FunctionalChannelType.MOTION_DETECTION_CHANNEL: MotionDetectionChannel,
@@ -272,6 +278,9 @@ FUNCTIONALCHANNEL_CLI_MAP = {
     FunctionalChannelType.DIMMER_CHANNEL: [
         CliActions.SET_DIM_LEVEL,
     ],
+    FunctionalChannelType.BACKLIGHT_CHANNEL: [
+        CliActions.SET_DIM_LEVEL,
+    ],
     FunctionalChannelType.MULTI_MODE_INPUT_DIMMER_CHANNEL: [CliActions.SET_DIM_LEVEL],
     FunctionalChannelType.NOTIFICATION_LIGHT_CHANNEL: [CliActions.SET_DIM_LEVEL],
     FunctionalChannelType.DOOR_LOCK_CHANNEL: [CliActions.SET_LOCK_STATE],
@@ -293,6 +302,7 @@ FUNCTIONALCHANNEL_CLI_MAP = {
     ],
     FunctionalChannelType.SHADING_CHANNEL: [CliActions.SET_SHUTTER_STOP],
     FunctionalChannelType.SWITCH_CHANNEL: [CliActions.SET_SWITCH_STATE],
+    FunctionalChannelType.EXTERNAL_SWITCH_CHANNEL: [CliActions.SET_SWITCH_STATE],
     FunctionalChannelType.SWITCH_MEASURING_CHANNEL: [CliActions.SET_SWITCH_STATE, CliActions.RESET_ENERGY_COUNTER],
     FunctionalChannelType.MULTI_MODE_INPUT_SWITCH_CHANNEL: [
         CliActions.SET_SWITCH_STATE

--- a/src/homematicip/device.py
+++ b/src/homematicip/device.py
@@ -108,6 +108,7 @@ class Device(BaseDevice):
         "IFeatureDeviceCoProRestart": ["coProRestartNeeded"],
         "IFeatureDeviceCoProUpdate": ["coProUpdateFailure"],
         "IFeatureDeviceIdentify": [],
+        "IFeatureDeviceMountingModuleError": ["mountingModuleError"],
         "IFeatureDeviceOverheated": ["deviceOverheated"],
         "IFeatureDeviceOverloaded": ["deviceOverloaded"],
         "IFeatureDeviceParticulateMatterSensorCommunicationError": "particulateMatterSensorCommunicationError",
@@ -145,7 +146,9 @@ class Device(BaseDevice):
         "IOptionalFeatureDeviceFrostProtectionError": ["frostProtectionError"],
         "IOptionalFeatureDeviceValveError": ["valveFlowError"],
         "IOptionalFeatureDeviceWaterError": ["valveWaterError"],
-        "IOptionalFeatureDeviceOperationMode": ["deviceOperationMode"]
+        "IOptionalFeatureDeviceOperationMode": ["deviceOperationMode"],
+        "IOptionalFeatureDeviceAliveSignalEnabled": ["deviceAliveSignalEnabled"],
+        "IOptionalFeatureDeviceSwitchChannelMode": ["switchChannelMode"]
     }
 
     def __init__(self, connection):
@@ -182,8 +185,11 @@ class Device(BaseDevice):
         self.busConfigMismatch = False
         self.shortCircuitDataLine = False
         self.powerShortCircuit = False
+        self.mountingModuleError = None
+        self.switchChannelMode = None
         self.deviceUndervoltage = False
         self.devicePowerFailureDetected = False
+        self.deviceAliveSignalEnabled = None
         self.deviceIdentifySupported = (
             False  # just placeholder at the moment the feature doesn't set any values
         )

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -481,6 +481,18 @@ def test_wall_mounted_thermostat_pro(fake_home: Home):
     assert d.id == "3014F7110000000000000WTH"
 
 
+def test_wall_mounted_glass_thermostat(fake_home: Home):
+    d = fake_home.search_device_by_id("3014F71100000000000000WGT")
+    assert isinstance(d, WallMountedThermostatPro)
+    assert d.deviceType == DeviceType.WALL_MOUNTED_GLASS_THERMOSTAT
+    assert d.modelType == "HmIP-WGT"
+    assert d.label.strip() == "Thermostat EG Wohnzimmer"
+    assert d.actualTemperature == 19.2
+    assert d.setPointTemperature == 22.0
+    assert d.humidity == 47
+    assert d.display == ClimateControlDisplay.ACTUAL
+
+
 def test_heating_thermostat(fake_home: Home):
     d = fake_home.search_device_by_id("3014F7110000000000000015")
     assert isinstance(d, HeatingThermostat)

--- a/tests/test_functional_channels.py
+++ b/tests/test_functional_channels.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch, AsyncMock
 
 from homematicip.base.channel_event import ChannelEvent
+from homematicip.base.enums import FunctionalChannelType
 from homematicip.base.functionalChannels import *
 from homematicip.device import *
 from homematicip.home import Home
@@ -141,6 +142,20 @@ def test_dimmer_channel(fake_home: Home):
         fake_home.get_current_state()
         ch = fake_home.search_channel("3014F711AAAA000000000005", 1)
         assert ch.dimLevel == 0.8
+
+
+def test_backlight_channel(fake_home: Home):
+    ch = fake_home.search_channel("3014F71100000000000000WGT", 2)
+    assert isinstance(ch, DimmerChannel)
+    assert ch.dimLevel == 1.0
+    assert ch.profileMode == "AUTOMATIC"
+    assert ch.userDesiredProfileMode == "AUTOMATIC"
+
+
+def test_input_quick_action_display_channel(fake_home: Home):
+    ch = fake_home.search_channel("3014F71100000000000000WGT", 1)
+    assert isinstance(ch, FunctionalChannel)
+    assert ch.functionalChannelType == FunctionalChannelType.INPUT_QUICK_ACTION_DISPLAY_CHANNEL
 
 
 def test_door_channel(fake_home: Home):


### PR DESCRIPTION
This PR adds recognition and parsing support for the HmIP‑WGT (glass thermostat) and several new enum/types that were causing warnings during device discovery.

Changes include:

Add new enums for device/group/channel/client types:
- DeviceType.WALL_MOUNTED_GLASS_THERMOSTAT
- DeviceType.PLUGIN_EXTERNAL
- GroupType.DEMAND_CONTROLLED_VENTILATION_GROUP
- FunctionalChannelType.BACKLIGHT_CHANNEL, INPUT_QUICK_ACTION_DISPLAY_CHANNEL, EXTERNAL_SWITCH_CHANNEL
- ClientType.PLUGIN

Map glass thermostat device type to existing WallMountedThermostatPro implementation.

Map BACKLIGHT_CHANNEL to DimmerChannel so backlight dimming is supported.

Add ExternalSwitchChannel to handle payloads that omit profileMode / userDesiredProfileMode.

Add support for optional device features: IFeatureDeviceMountingModuleError, IOptionalFeatureDeviceSwitchChannelMode, IOptionalFeatureDeviceAliveSignalEnabled.

Map DEMAND_CONTROLLED_VENTILATION_GROUP to Group.

Map PLUGIN_EXTERNAL to ExternalDevice.

Notes:

Attached is a wgt.json device payload.
[wgt.json](https://github.com/user-attachments/files/24561788/wgt.json)

I ran into this issue, since HomeAssistant would not show the HmIP-WGT as sensors (I did get controls, though), so I could not use current temp in graphs for instance. See https://github.com/home-assistant/core/issues/160701 for details.
