### PR TITLE
feat: add extended properties for HmIP-FALMOT floor terminal block

### DIFF
--- a/homematicip_demo/json_data/home.json
+++ b/homematicip_demo/json_data/home.json
@@ -2875,11 +2875,17 @@
         },
         "1": {
           "deviceId": "3014F7110000000000FALMOT",
+          "dewPointAlarmActive": false,
+          "emergencyOperationActive": false,
+          "externalClockActive": false,
+          "frostProtectionActive": false,
           "functionalChannelType": "FLOOR_TERMINAL_BLOCK_MECHANIC_CHANNEL",
           "groupIndex": 1,
           "groups": [
             "00000000-0000-0000-0000-000000000016"
           ],
+          "humidityLimiterAlarm": false,
+          "humidityLimiterPreAlarm": false,
           "index": 1,
           "label": "Kanal 1",
           "valvePosition": 0.5,

--- a/src/homematicip/base/functionalChannels.py
+++ b/src/homematicip/base/functionalChannels.py
@@ -466,6 +466,7 @@ class DeviceBaseFloorHeatingChannel(DeviceBaseChannel):
         self.frostProtectionTemperature = 0.0
         self.heatingEmergencyValue = 0.0
         self.minimumFloorHeatingValvePosition = 0.0
+        self.pulseWidthModulationAtLowFloorHeatingValvePositionEnabled = False
         self.temperatureOutOfRange = False
         self.valveProtectionDuration = 0
         self.valveProtectionSwitchingInterval = 20
@@ -476,6 +477,7 @@ class DeviceBaseFloorHeatingChannel(DeviceBaseChannel):
         self.set_attr_from_dict("frostProtectionTemperature", js)
         self.set_attr_from_dict("heatingEmergencyValue", js)
         self.set_attr_from_dict("minimumFloorHeatingValvePosition", js)
+        self.set_attr_from_dict("pulseWidthModulationAtLowFloorHeatingValvePositionEnabled", js)
         self.set_attr_from_dict("temperatureOutOfRange", js)
         self.set_attr_from_dict("valveProtectionDuration", js)
         self.set_attr_from_dict("valveProtectionSwitchingInterval", js)
@@ -1822,12 +1824,24 @@ class FloorTerminalBlockMechanicChannel(FunctionalChannel):
         #:ValveState:the current valve state
         self.valveState = ValveState.ADAPTION_DONE
         self.valvePosition = 0.0
+        self.dewPointAlarmActive = False
+        self.emergencyOperationActive = False
+        self.externalClockActive = False
+        self.frostProtectionActive = False
+        self.humidityLimiterAlarm = False
+        self.humidityLimiterPreAlarm = False
 
     def from_json(self, js, groups: Iterable[Group]):
         super().from_json(js, groups)
         self.set_attr_from_dict("valveState", js, ValveState)
         if "valvePosition" in js:
             self.set_attr_from_dict("valvePosition", js)
+        self.set_attr_from_dict("dewPointAlarmActive", js)
+        self.set_attr_from_dict("emergencyOperationActive", js)
+        self.set_attr_from_dict("externalClockActive", js)
+        self.set_attr_from_dict("frostProtectionActive", js)
+        self.set_attr_from_dict("humidityLimiterAlarm", js)
+        self.set_attr_from_dict("humidityLimiterPreAlarm", js)
 
 
 class ChangeOverChannel(FunctionalChannel):

--- a/src/homematicip/device.py
+++ b/src/homematicip/device.py
@@ -816,6 +816,7 @@ class FloorTerminalBlock12(Device):
     def __init__(self, connection):
         super().__init__(connection)
         self.frostProtectionTemperature = 0.0
+        self.heatingEmergencyValue = 0.0
         self.valveProtectionDuration = 0
         self.valveProtectionSwitchingInterval = 20
         self.coolingEmergencyValue = 0
@@ -830,6 +831,9 @@ class FloorTerminalBlock12(Device):
         if c:
             self.set_attr_from_dict("coolingEmergencyValue", c)
             self.set_attr_from_dict("frostProtectionTemperature", c)
+            self.set_attr_from_dict("heatingEmergencyValue", c)
+            self.set_attr_from_dict("minimumFloorHeatingValvePosition", c)
+            self.set_attr_from_dict("pulseWidthModulationAtLowFloorHeatingValvePositionEnabled", c)
             self.set_attr_from_dict("valveProtectionDuration", c)
             self.set_attr_from_dict("valveProtectionSwitchingInterval", c)
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1399,7 +1399,8 @@ def test_floor_terminal_block(fake_home: Home):
             "rssiDeviceValue(-55) rssiPeerValue(None) configPending(False) dutyCycle(False) "
             "minimumFloorHeatingValvePosition(0.2) "
             "pulseWidthModulationAtLowFloorHeatingValvePositionEnabled(True) coolingEmergencyValue(0.0) "
-            "frostProtectionTemperature(8.0) valveProtectionDuration(5) valveProtectionSwitchingInterval(14)"
+            "frostProtectionTemperature(8.0) heatingEmergencyValue(0.25) "
+            "valveProtectionDuration(5) valveProtectionSwitchingInterval(14)"
         )
 
         d = FloorTerminalBlock12(fake_home._connection)
@@ -1414,7 +1415,8 @@ def test_floor_terminal_block(fake_home: Home):
             "rssiDeviceValue(-62) rssiPeerValue(None) configPending(False) dutyCycle(False) "
             "minimumFloorHeatingValvePosition(0.2) "
             "pulseWidthModulationAtLowFloorHeatingValvePositionEnabled(False) coolingEmergencyValue(0.0) "
-            "frostProtectionTemperature(5.0) valveProtectionDuration(5) valveProtectionSwitchingInterval(14)"
+            "frostProtectionTemperature(5.0) heatingEmergencyValue(0.25) "
+            "valveProtectionDuration(5) valveProtectionSwitchingInterval(14)"
         )
 
         c = d.functionalChannels[1]
@@ -1422,6 +1424,12 @@ def test_floor_terminal_block(fake_home: Home):
         assert c.valveState == ValveState.ADAPTION_DONE
         assert c.valvePosition == 0.5
         assert c.label == "Kanal 1"
+        assert c.dewPointAlarmActive is False
+        assert c.emergencyOperationActive is False
+        assert c.externalClockActive is False
+        assert c.frostProtectionActive is False
+        assert c.humidityLimiterAlarm is False
+        assert c.humidityLimiterPreAlarm is False
 
         d = WiredFloorTerminalBlock12(fake_home._connection)
         d = fake_home.search_device_by_id("3014F7110000000000000053")
@@ -1435,7 +1443,8 @@ def test_floor_terminal_block(fake_home: Home):
             "rssiDeviceValue(None) rssiPeerValue(None) configPending(False) dutyCycle(None) "
             "minimumFloorHeatingValvePosition(0.2) "
             "pulseWidthModulationAtLowFloorHeatingValvePositionEnabled(False) coolingEmergencyValue(0.0) "
-            "frostProtectionTemperature(8.0) valveProtectionDuration(5) valveProtectionSwitchingInterval(14)"
+            "frostProtectionTemperature(8.0) heatingEmergencyValue(0.0) "
+            "valveProtectionDuration(5) valveProtectionSwitchingInterval(14)"
         )
 
 


### PR DESCRIPTION
## Summary

Extends floor terminal block channels with additional properties from the cloud API:

**DeviceBaseFloorHeatingChannel:**
- `pulseWidthModulationAtLowFloorHeatingValvePositionEnabled` (bool) - PWM mode at low valve position

**FloorTerminalBlock12.from_json:**
- `heatingEmergencyValue` (float) - emergency heating valve position
- `minimumFloorHeatingValvePosition` (float) - minimum valve position
- `pulseWidthModulationAtLowFloorHeatingValvePositionEnabled` (bool)

**FloorTerminalBlockMechanicChannel (per-valve status):**
- `dewPointAlarmActive` (bool) - dew point alarm active
- `emergencyOperationActive` (bool) - emergency operation mode
- `externalClockActive` (bool) - external clock signal active
- `frostProtectionActive` (bool) - frost protection mode active
- `humidityLimiterAlarm` (bool) - humidity limiter alarm
- `humidityLimiterPreAlarm` (bool) - humidity limiter pre-alarm

## Test plan

- [x] Updated test fixture with real device data (anonymized)
- [x] Updated `test_floor_terminal_block` to verify new properties
- [x] All 234 tests pass