### PR TITLE
Update CHANGELOG for 2.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [UNRELEASED](https://github.com/hahn-th/homematicip-rest-api/compare/2.5.0..master)
+## [UNRELEASED](https://github.com/hahn-th/homematicip-rest-api/compare/2.6.0..master)
+
+## [2.6.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.5.0..2.6.0)
 
 ### Added
 
@@ -16,10 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for ELV-SH-SB8 Status Board
 - Add support for ELV-SH-PSMCI (Switch Measuring Cable Indoor)
 - Add test coverage for HmIPW-DRI16 (Wired Input 16)
+- Add HmipAuthenticationError for HTTP 403 responses
 
 ### Changed
 
 - Add missing fields to floor terminal block channels (HmIP-FALMOT)
+
+### Fixed
+
+- Fix duplicate getCurrentState API call in hmip_cli
 
 ## [2.5.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.4.0..2.5.0) 2026-01-13
 


### PR DESCRIPTION
Add two entries that were merged after the changelog PR #628:
- **#629** — `HmipAuthenticationError` for HTTP 403 responses (Added)
- **#626** — Fix duplicate `getCurrentState` API call in `hmip_cli` (Fixed)

Rename UNRELEASED → 2.6.0.