### PR TITLE
Fix docs build pipeline failure

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,6 @@ plugins:
           show_submodules: false
           summary: false
           show_source: false
-          load_external_modules: false
           members_order: alphabetical
 - api-autonav:
     modules: ['src/homematicip']


### PR DESCRIPTION
Remove `load_external_modules` option from mkdocstrings handler `options` block. Since v1.6.3 this is a global-only option that belongs at the handler level, not inside `options`. Placing it there causes:

```
PythonOptions.__init__() got an unexpected keyword argument 'load_external_modules'
```

Since the value was `false` (which is the default behavior), removing it entirely is the correct fix.

Fixes #632