### PR TITLE
Add HmIP-SMO230 (Motion Detector with Brightness Sensor and Switch - outdoor) support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for ELV-SH-SPS25 (Switchable Power Supply)
 - Add support for ELV-SH-PTI2 (Temperature Difference Sensor 2 - Platin)
+- Add support for HmIP-SMO230 (Motion Detector with Brightness Sensor and Switch - outdoor)
 
 ## [2.6.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.5.0..2.6.0)
 

--- a/src/homematicip/device.py
+++ b/src/homematicip/device.py
@@ -98,6 +98,22 @@ class BaseDevice(HomeMaticIPObject):
         fc.device = self
         return fc
 
+    def get_functional_channel(
+            self, channel_type: FunctionalChannelType | str, index: int | None = None
+    ) -> FunctionalChannel | None:
+        """Return the loaded functional channel matching the given type and optional index."""
+        if isinstance(channel_type, str):
+            channel_type = FunctionalChannelType.from_str(channel_type, channel_type)
+
+        for channel in self.functionalChannels:
+            if channel.functionalChannelType != channel_type:
+                continue
+            if index is not None and channel.index != index:
+                continue
+            return channel
+
+        return None
+
 
 class Device(BaseDevice):
     """this class represents a generic homematic ip device"""
@@ -2835,33 +2851,56 @@ class DaliGateway(Device):
 class MotionDetectorSwitchOutdoor(SabotageDevice):
     """HmIP-SMO230 (Motion Detector with Brightness Sensor and Switch - outdoor)"""
 
-    def __init__(self, connection):
-        super().__init__(connection)
-        self.currentIllumination = None
-        self.motionDetected = None
-        self.illumination = None
-        self.motionBufferActive = False
-        self.motionDetectionSendInterval = MotionDetectionSendInterval.SECONDS_30
-        self.numberOfBrightnessMeasurements = 0
-        self.on = None
-        self.profileMode = None
-        self.userDesiredProfileMode = None
+    def _get_motion_detection_channel(self):
+        return self.get_functional_channel(FunctionalChannelType.MOTION_DETECTION_CHANNEL)
 
-    def from_json(self, js):
-        super().from_json(js)
-        c = get_functional_channel("MOTION_DETECTION_CHANNEL", js)
-        if c:
-            self.set_attr_from_dict("motionDetected", c)
-            self.set_attr_from_dict("illumination", c)
-            self.set_attr_from_dict("motionBufferActive", c)
-            self.set_attr_from_dict("motionDetectionSendInterval", c)
-            self.set_attr_from_dict("numberOfBrightnessMeasurements", c)
-            self.set_attr_from_dict("currentIllumination", c)
-        c = get_functional_channel("SWITCH_CHANNEL", js)
-        if c:
-            self.on = c["on"]
-            self.profileMode = c["profileMode"]
-            self.userDesiredProfileMode = c["userDesiredProfileMode"]
+    def _get_switch_channel(self):
+        return self.get_functional_channel(FunctionalChannelType.SWITCH_CHANNEL)
+
+    @property
+    def currentIllumination(self):
+        channel = self._get_motion_detection_channel()
+        return channel.currentIllumination if channel else None
+
+    @property
+    def motionDetected(self):
+        channel = self._get_motion_detection_channel()
+        return channel.motionDetected if channel else None
+
+    @property
+    def illumination(self):
+        channel = self._get_motion_detection_channel()
+        return channel.illumination if channel else None
+
+    @property
+    def motionBufferActive(self):
+        channel = self._get_motion_detection_channel()
+        return channel.motionBufferActive if channel else False
+
+    @property
+    def motionDetectionSendInterval(self):
+        channel = self._get_motion_detection_channel()
+        return channel.motionDetectionSendInterval if channel else MotionDetectionSendInterval.SECONDS_30
+
+    @property
+    def numberOfBrightnessMeasurements(self):
+        channel = self._get_motion_detection_channel()
+        return channel.numberOfBrightnessMeasurements if channel else 0
+
+    @property
+    def on(self):
+        channel = self._get_switch_channel()
+        return channel.on if channel else None
+
+    @property
+    def profileMode(self):
+        channel = self._get_switch_channel()
+        return channel.profileMode if channel else None
+
+    @property
+    def userDesiredProfileMode(self):
+        channel = self._get_switch_channel()
+        return channel.userDesiredProfileMode if channel else None
 
     def __str__(self):
         return "{} motionDetected({}) illumination({}) on({})".format(
@@ -2871,24 +2910,29 @@ class MotionDetectorSwitchOutdoor(SabotageDevice):
             self.on,
         )
 
-    def set_switch_state(self, on=True, channelIndex=2):
-        return self._run_non_async(self.set_switch_state_async, on, channelIndex)
+    def set_switch_state(self, on=True):
+        channel = self._get_switch_channel()
+        if channel is None:
+            raise AttributeError("SWITCH_CHANNEL not loaded for device")
+        return channel.set_switch_state(on)
 
-    async def set_switch_state_async(self, on=True, channelIndex=2):
-        data = {"channelIndex": channelIndex, "deviceId": self.id, "on": on}
-        return await self._rest_call_async("device/control/setSwitchState", body=data)
+    async def set_switch_state_async(self, on=True):
+        channel = self._get_switch_channel()
+        if channel is None:
+            raise AttributeError("SWITCH_CHANNEL not loaded for device")
+        return await channel.async_set_switch_state(on)
 
-    def turn_on(self, channelIndex=2):
-        return self._run_non_async(self.turn_on_async, channelIndex)
+    def turn_on(self):
+        return self.set_switch_state(True)
 
-    async def turn_on_async(self, channelIndex=2):
-        return await self.set_switch_state_async(True, channelIndex)
+    async def turn_on_async(self):
+        return await self.set_switch_state_async(True)
 
-    def turn_off(self, channelIndex=2):
-        return self._run_non_async(self.turn_off_async, channelIndex)
+    def turn_off(self):
+        return self.set_switch_state(False)
 
-    async def turn_off_async(self, channelIndex=2):
-        return await self.set_switch_state_async(False, channelIndex)
+    async def turn_off_async(self):
+        return await self.set_switch_state_async(False)
 
 
 class WallMountedKeyPad(Device):

--- a/src/homematicip/device.py
+++ b/src/homematicip/device.py
@@ -2851,6 +2851,9 @@ class DaliGateway(Device):
 class MotionDetectorSwitchOutdoor(SabotageDevice):
     """HmIP-SMO230 (Motion Detector with Brightness Sensor and Switch - outdoor)"""
 
+    def __init__(self, connection):
+        super().__init__(connection)
+
     def _get_motion_detection_channel(self):
         return self.get_functional_channel(FunctionalChannelType.MOTION_DETECTION_CHANNEL)
 

--- a/src/homematicip/device.py
+++ b/src/homematicip/device.py
@@ -2832,8 +2832,63 @@ class DaliGateway(Device):
     pass
 
 
-class MotionDetectorSwitchOutdoor(Device):
-    pass
+class MotionDetectorSwitchOutdoor(SabotageDevice):
+    """HmIP-SMO230 (Motion Detector with Brightness Sensor and Switch - outdoor)"""
+
+    def __init__(self, connection):
+        super().__init__(connection)
+        self.currentIllumination = None
+        self.motionDetected = None
+        self.illumination = None
+        self.motionBufferActive = False
+        self.motionDetectionSendInterval = MotionDetectionSendInterval.SECONDS_30
+        self.numberOfBrightnessMeasurements = 0
+        self.on = None
+        self.profileMode = None
+        self.userDesiredProfileMode = None
+
+    def from_json(self, js):
+        super().from_json(js)
+        c = get_functional_channel("MOTION_DETECTION_CHANNEL", js)
+        if c:
+            self.set_attr_from_dict("motionDetected", c)
+            self.set_attr_from_dict("illumination", c)
+            self.set_attr_from_dict("motionBufferActive", c)
+            self.set_attr_from_dict("motionDetectionSendInterval", c)
+            self.set_attr_from_dict("numberOfBrightnessMeasurements", c)
+            self.set_attr_from_dict("currentIllumination", c)
+        c = get_functional_channel("SWITCH_CHANNEL", js)
+        if c:
+            self.on = c["on"]
+            self.profileMode = c["profileMode"]
+            self.userDesiredProfileMode = c["userDesiredProfileMode"]
+
+    def __str__(self):
+        return "{} motionDetected({}) illumination({}) on({})".format(
+            super().__str__(),
+            self.motionDetected,
+            self.illumination,
+            self.on,
+        )
+
+    def set_switch_state(self, on=True, channelIndex=2):
+        return self._run_non_async(self.set_switch_state_async, on, channelIndex)
+
+    async def set_switch_state_async(self, on=True, channelIndex=2):
+        data = {"channelIndex": channelIndex, "deviceId": self.id, "on": on}
+        return await self._rest_call_async("device/control/setSwitchState", body=data)
+
+    def turn_on(self, channelIndex=2):
+        return self._run_non_async(self.turn_on_async, channelIndex)
+
+    async def turn_on_async(self, channelIndex=2):
+        return await self.set_switch_state_async(True, channelIndex)
+
+    def turn_off(self, channelIndex=2):
+        return self._run_non_async(self.turn_off_async, channelIndex)
+
+    async def turn_off_async(self, channelIndex=2):
+        return await self.set_switch_state_async(False, channelIndex)
 
 
 class WallMountedKeyPad(Device):

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1976,6 +1976,24 @@ def test_motion_detector_switch_outdoor(fake_home: Home):
         assert "on(False)" in str(d)
         assert "sabotage(False)" in str(d)
 
+        motion_channel = d.get_functional_channel(FunctionalChannelType.MOTION_DETECTION_CHANNEL)
+        switch_channel = d.get_functional_channel(FunctionalChannelType.SWITCH_CHANNEL)
+        sabotage_channel = d.get_functional_channel(FunctionalChannelType.DEVICE_SABOTAGE)
+
+        assert isinstance(motion_channel, MotionDetectionChannel)
+        assert isinstance(switch_channel, SwitchChannel)
+        assert isinstance(sabotage_channel, DeviceSabotageChannel)
+
+        assert motion_channel.motionDetected is False
+        assert motion_channel.illumination == 3158.0
+        assert motion_channel.motionBufferActive is True
+        assert motion_channel.motionDetectionSendInterval == MotionDetectionSendInterval.SECONDS_30
+        assert motion_channel.numberOfBrightnessMeasurements == 3
+        assert switch_channel.on is False
+        assert switch_channel.profileMode == "AUTOMATIC"
+        assert switch_channel.userDesiredProfileMode == "AUTOMATIC"
+        assert sabotage_channel.sabotage is False
+
 
 def test_wall_mounted_keypad(fake_home: Home):
     with no_ssl_verification():

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1961,6 +1961,20 @@ def test_motion_detector_switch_outdoor(fake_home: Home):
     with no_ssl_verification():
         d = fake_home.search_device_by_id("3014F711000000000SMO230A")
         assert isinstance(d, MotionDetectorSwitchOutdoor)
+        assert d.sabotage is False
+        assert d.motionDetected is False
+        assert d.illumination == 3158.0
+        assert d.currentIllumination is None
+        assert d.motionBufferActive is True
+        assert d.motionDetectionSendInterval == MotionDetectionSendInterval.SECONDS_30
+        assert d.numberOfBrightnessMeasurements == 3
+        assert d.on is False
+        assert d.profileMode == "AUTOMATIC"
+        assert d.userDesiredProfileMode == "AUTOMATIC"
+        assert "motionDetected(False)" in str(d)
+        assert "illumination(3158.0)" in str(d)
+        assert "on(False)" in str(d)
+        assert "sabotage(False)" in str(d)
 
 
 def test_wall_mounted_keypad(fake_home: Home):


### PR DESCRIPTION
Implement `MotionDetectorSwitchOutdoor` which was previously an empty stub.

The HmIP-SMO230 has three functional channels:
- **DEVICE_SABOTAGE** (ch0) — sabotage detection
- **MOTION_DETECTION_CHANNEL** (ch1) — motion detection, illumination, brightness measurements
- **SWITCH_CHANNEL** (ch2) — on/off switch control

Implementation:
- Inherits from `SabotageDevice` for sabotage detection
- Parses motion detection properties (motionDetected, illumination, motionBufferActive, etc.)
- Parses switch state (on, profileMode, userDesiredProfileMode)
- Switch control methods use `channelIndex=2` matching the device's channel layout

Closes #639