### PR TITLE
Harden auth logging and add review tracker

### DIFF
--- a/review.md
+++ b/review.md
@@ -1,0 +1,84 @@
+# Code Review Findings
+
+This file tracks the current review findings so we can work them down one by one without losing context.
+
+## Open
+
+### 1. Sensitive data can leak into logs
+
+- Severity: High
+- Area: Security
+- Files:
+  - `src/homematicip/auth.py`
+  - `src/homematicip/connection/rest_connection.py`
+- Summary:
+  - Auth flows log raw `RestResult` objects and request/response details.
+  - Error logging includes full response bodies and request payloads.
+  - Current redaction only handles a top-level `id`, so tokens, PINs, client IDs, and access point identifiers can leak into logs.
+- Status:
+  - Addressed in the current PR by adding recursive redaction and replacing raw auth-result logging with status-only logs.
+
+### 2. Websocket connection state checks use method objects instead of booleans
+
+- Severity: High
+- Area: Correctness / Maintainability
+- Files:
+  - `src/homematicip/async_home.py`
+- Summary:
+  - `enable_events()` checks `self._websocket_client.is_connected` instead of `is_connected()`.
+  - `websocket_is_connected()` returns the bound method object instead of a boolean.
+  - This can suppress reconnect attempts and mislead callers about actual websocket state.
+- Status:
+  - Not started.
+
+### 3. Rate limiter is not concurrency-safe and adds unnecessary latency
+
+- Severity: Medium
+- Area: Efficiency / Correctness
+- Files:
+  - `src/homematicip/connection/buckets.py`
+- Summary:
+  - `wait_and_take()` mutates token state without holding the lock used by `take()`.
+  - Concurrent callers can oversubscribe the bucket.
+  - The fixed 1-second polling interval is coarse and increases avoidable wait time.
+- Status:
+  - Not started.
+
+### 4. One bad device payload can abort the entire device refresh
+
+- Severity: Medium
+- Area: Reliability / Maintainability
+- Files:
+  - `src/homematicip/async_home.py`
+- Summary:
+  - `_get_devices()` stops processing all remaining devices after the first parse/update exception.
+  - That can leave the in-memory state partially updated without surfacing a failure to the caller.
+- Status:
+  - Not started.
+
+### 5. Broad exception fallbacks hide programming bugs as “unknown type” cases
+
+- Severity: Medium
+- Area: Maintainability
+- Files:
+  - `src/homematicip/async_home.py`
+- Summary:
+  - Device, rule, and group parsing use broad `except` fallbacks.
+  - This masks genuine implementation errors like `KeyError`, `TypeError`, and mapping bugs.
+- Status:
+  - Not started.
+
+### 6. HTTP client reuse and SSL behavior are inconsistent with the public API
+
+- Severity: Low
+- Area: Efficiency / Security / Maintainability
+- Files:
+  - `src/homematicip/connection/rest_connection.py`
+  - `src/homematicip/connection/connection_url_resolver.py`
+  - `src/homematicip/connection/websocket_handler.py`
+- Summary:
+  - A new `httpx.AsyncClient` is created per request when no session is injected, which loses pooling benefits.
+  - The documented `enforce_ssl=False` behavior does not match implementation.
+  - Websocket SSL setup uses `ssl_ctx` directly and does not follow the same verification semantics as the REST path.
+- Status:
+  - Not started.

--- a/src/homematicip/auth.py
+++ b/src/homematicip/auth.py
@@ -42,7 +42,7 @@ class Auth:
         self.pin = pin
 
     async def connection_request(self, access_point: str, device_name="homematicip-python") -> RestResult:
-        LOGGER.debug(f"Requesting connection for access point {access_point}")
+        LOGGER.debug("Requesting connection for access point [REDACTED]")
         headers = self.headers.copy()
         if self.pin is not None:
             headers["PIN"] = self.pin
@@ -64,7 +64,7 @@ class Auth:
 
         result = await self.connection.async_post("auth/isRequestAcknowledged", data, self.headers)
 
-        LOGGER.debug(f"Request acknowledged result: {result}")
+        LOGGER.debug("Request acknowledged check finished with status %s", result.status)
         return result.status == 200
 
     async def request_auth_token(self) -> str:
@@ -73,7 +73,7 @@ class Auth:
         LOGGER.debug("Requesting auth token")
         data = {"deviceId": self.client_id}
         result = await self.connection.async_post("auth/requestAuthToken", data, self.headers)
-        LOGGER.debug(f"Request auth token result: {result}")
+        LOGGER.debug("Auth token request finished with status %s", result.status)
 
         return result.json["authToken"]
 
@@ -85,7 +85,7 @@ class Auth:
         LOGGER.debug("Confirming auth token")
         data = {"deviceId": self.client_id, "authToken": auth_token}
         result = await self.connection.async_post("auth/confirmAuthToken", data, self.headers)
-        LOGGER.debug(f"Confirm auth token result: {result}")
+        LOGGER.debug("Auth token confirmation finished with status %s", result.status)
 
         return result.json["clientId"]
 

--- a/src/homematicip/connection/rest_connection.py
+++ b/src/homematicip/connection/rest_connection.py
@@ -2,7 +2,7 @@ import json
 import logging
 from dataclasses import dataclass
 from ssl import SSLContext
-from typing import Optional
+from typing import Any, Optional
 
 import httpx
 
@@ -11,6 +11,21 @@ from homematicip.connection.connection_context import ConnectionContext
 from homematicip.exceptions.connection_exceptions import HmipThrottlingError
 
 LOGGER = logging.getLogger(__name__)
+
+SENSITIVE_LOG_KEYS = {
+    "accessPointId",
+    "ACCESSPOINT-ID",
+    "authToken",
+    "AUTHTOKEN",
+    "clientAuthToken",
+    "CLIENTAUTH",
+    "clientId",
+    "deviceId",
+    "id",
+    "pin",
+    "PIN",
+    "sgtin",
+}
 
 
 @dataclass
@@ -72,6 +87,23 @@ class RestConnection:
         """If headers must be manipulated use this method to get the current headers."""
         return self._headers
 
+    @staticmethod
+    def _redact_sensitive_data(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {
+                key: (
+                    "REDACTED"
+                    if key in SENSITIVE_LOG_KEYS
+                    else RestConnection._redact_sensitive_data(item)
+                )
+                for key, item in value.items()
+            }
+
+        if isinstance(value, list):
+            return [RestConnection._redact_sensitive_data(item) for item in value]
+
+        return value
+
     async def async_post(self, url: str, data: dict | None = None, custom_header: dict | None = None) -> RestResult:
         """Send an async post request to cloud with json data. Returns a json result.
         @param url: The path of the url to send the request to
@@ -82,17 +114,15 @@ class RestConnection:
         """
         full_url = self._build_url(self._context.rest_url, url)
         try:
-            data_logging = data.copy() if data is not None else {}
-            if "id" in data_logging:
-                data_logging["id"] = "REDACTED"
+            data_logging = self._redact_sensitive_data(data or {})
 
             header = self._headers
             if custom_header is not None:
                 header = custom_header
 
-            LOGGER.debug(f"Sending post request to url {full_url}. Data is: {data_logging}")
+            LOGGER.debug("Sending post request to url %s. Data is: %s", full_url, data_logging)
             r = await self._execute_request_async(full_url, data, header)
-            LOGGER.debug(f"Got response {r.status_code}.")
+            LOGGER.debug("Got response %s.", r.status_code)
 
             if r.status_code == THROTTLE_STATUS_CODE:
                 LOGGER.error("Got error 429 (Throttling active)")
@@ -108,12 +138,15 @@ class RestConnection:
 
             return result
         except httpx.RequestError as exc:
-            LOGGER.error(f"An error occurred while requesting {exc.request.url!r}.")
+            LOGGER.error("An error occurred while requesting %r.", exc.request.url)
             return RestResult(status=-1, exception=exc)
         except httpx.HTTPStatusError as exc:
             if self._log_status_exceptions:
                 LOGGER.error(
-                    f"Error response {exc.response.status_code} ({exc.response.text}) while requesting {exc.request.url!r} with data {data_logging if data_logging is not None else "<no-data>"}."
+                    "Error response %s while requesting %r with data %s.",
+                    exc.response.status_code,
+                    exc.request.url,
+                    data_logging if data_logging is not None else "<no-data>",
                 )
             return RestResult(status=exc.response.status_code, exception=exc, text=exc.response.text)
 

--- a/tests/connection/test_rest_connection.py
+++ b/tests/connection/test_rest_connection.py
@@ -76,3 +76,33 @@ async def test_conn_async_post_with_httpx_client_session(mocker):
     assert mock_client.post.call_args[0][0] == "http://asdf/hmip/url"
     assert mock_client.post.call_args[1] == {"json": {"a": "b"}, "headers": {"c": "d"}}
     assert result.status == 200
+
+
+def test_redact_sensitive_data_nested():
+    redacted = RestConnection._redact_sensitive_data(
+        {
+            "id": "device-id",
+            "deviceId": "device-id",
+            "authToken": "secret-token",
+            "sgtin": "access-point-id",
+            "nested": {
+                "clientId": "client-id",
+                "PIN": "1234",
+                "safe": "value",
+            },
+            "items": [
+                {"ACCESSPOINT-ID": "access-point-id"},
+                {"value": "still-visible"},
+            ],
+        }
+    )
+
+    assert redacted["id"] == "REDACTED"
+    assert redacted["deviceId"] == "REDACTED"
+    assert redacted["authToken"] == "REDACTED"
+    assert redacted["sgtin"] == "REDACTED"
+    assert redacted["nested"]["clientId"] == "REDACTED"
+    assert redacted["nested"]["PIN"] == "REDACTED"
+    assert redacted["nested"]["safe"] == "value"
+    assert redacted["items"][0]["ACCESSPOINT-ID"] == "REDACTED"
+    assert redacted["items"][1]["value"] == "still-visible"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,7 @@
+import asyncio
 import hashlib
+import logging
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -32,3 +35,28 @@ async def test_async_auth_challenge_no_pin(
 
     result_id = await auth.confirm_auth_token(token)
     assert result_id == auth.client_id
+
+
+def test_auth_logging_does_not_log_tokens_or_pin(caplog):
+    connection = AsyncMock(spec=RestConnection)
+    connection.async_post.side_effect = [
+        Mock(status=200, json={}),
+        Mock(status=200, json={"authToken": "TOPSECRET"}),
+        Mock(status=200, json={"clientId": "CLIENTSECRET"}),
+    ]
+
+    auth = Auth(connection, "CLIENTAUTHSECRET", "ACCESSPOINTSECRET")
+    auth.set_pin("1234")
+
+    async def _run():
+        with caplog.at_level(logging.DEBUG):
+            await auth.connection_request("ACCESSPOINTSECRET")
+            await auth.request_auth_token()
+            await auth.confirm_auth_token("TOPSECRET")
+
+    asyncio.run(_run())
+
+    assert "TOPSECRET" not in caplog.text
+    assert "CLIENTSECRET" not in caplog.text
+    assert "1234" not in caplog.text
+    assert "ACCESSPOINTSECRET" not in caplog.text

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -48,13 +48,25 @@ def test_auth_logging_does_not_log_tokens_or_pin(caplog):
     auth = Auth(connection, "CLIENTAUTHSECRET", "ACCESSPOINTSECRET")
     auth.set_pin("1234")
 
+    try:
+        previous_loop = asyncio.get_event_loop_policy().get_event_loop()
+    except RuntimeError:
+        previous_loop = None
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
     async def _run():
         with caplog.at_level(logging.DEBUG):
             await auth.connection_request("ACCESSPOINTSECRET")
             await auth.request_auth_token()
             await auth.confirm_auth_token("TOPSECRET")
 
-    asyncio.run(_run())
+    try:
+        loop.run_until_complete(_run())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(previous_loop)
 
     assert "TOPSECRET" not in caplog.text
     assert "CLIENTSECRET" not in caplog.text


### PR DESCRIPTION
## Summary
- harden auth and REST logging so tokens, PINs, client IDs, access point identifiers, and `sgtin` values are redacted from request logs
- stop logging raw auth `RestResult` payloads and log statuses instead
- add `review.md` to track the remaining security, efficiency, and maintainability findings
- add targeted tests for redaction and auth logging behavior

## Testing
- `PYTHONPATH=src pytest -q tests/connection/test_rest_connection.py::test_redact_sensitive_data_nested tests/test_auth.py::test_auth_logging_does_not_log_tokens_or_pin`

## Notes
- the local test environment in this workspace does not currently have the pytest async/mock plugins configured, so verification here is focused on the new targeted coverage