### PR TITLE
Fix websocket connection state checks

### DIFF
--- a/src/homematicip/async_home.py
+++ b/src/homematicip/async_home.py
@@ -655,7 +655,7 @@ class AsyncHome(HomeMaticIPObject):
 
     async def enable_events(self, additional_message_handler: Callable = None):
         """Connect to Websocket and listen for events"""
-        if self._websocket_client and self._websocket_client.is_connected:
+        if self._websocket_client and self._websocket_client.is_connected():
             return
 
         self._websocket_client = WebsocketHandler()
@@ -766,7 +766,7 @@ class AsyncHome(HomeMaticIPObject):
 
     def websocket_is_connected(self):
         """returns if the websocket is connected."""
-        return self._websocket_client.is_connected if self._websocket_client else False
+        return self._websocket_client.is_connected() if self._websocket_client else False
 
     def set_on_connected_handler(self, handler: Callable):
         """Sets a callback that is called when the WebSocket connection is established."""

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -780,9 +780,26 @@ async def test_enable_events(fake_home):
 @pytest.mark.asyncio
 async def test_enable_events_active(fake_home):
     fake_home._websocket_client = Mock()
+    fake_home._websocket_client.is_connected.return_value = True
     await fake_home.enable_events()
 
     assert not fake_home._websocket_client.start.called
+
+
+@pytest.mark.asyncio
+async def test_enable_events_reconnects_when_client_exists_but_is_disconnected(fake_home):
+    stale_websocket_handler = Mock()
+    stale_websocket_handler.is_connected.return_value = False
+    fake_home._websocket_client = stale_websocket_handler
+
+    new_websocket_handler = Mock()
+    new_websocket_handler.start = AsyncMock()
+
+    with patch('homematicip.async_home.WebsocketHandler', return_value=new_websocket_handler):
+        await fake_home.enable_events()
+
+    assert fake_home._websocket_client is new_websocket_handler
+    new_websocket_handler.start.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -793,3 +810,12 @@ async def test_disable_events(fake_home):
 
     assert fake_home._websocket_client is None
     assert fake_client.stop.called
+
+
+def test_websocket_is_connected_returns_bool(fake_home):
+    assert fake_home.websocket_is_connected() is False
+
+    fake_home._websocket_client = Mock()
+    fake_home._websocket_client.is_connected.return_value = True
+
+    assert fake_home.websocket_is_connected() is True


### PR DESCRIPTION
## Summary
- call `is_connected()` instead of treating the bound method as a truthy object in `AsyncHome.enable_events()`
- make `websocket_is_connected()` return a real boolean
- add regression tests for the already-connected case, the stale-disconnected-client case, and the boolean return value

## Testing
- attempted focused local pytest for `tests/test_home.py`, but execution is currently blocked on upstream `master` by an existing syntax error in `src/homematicip/connection/rest_connection.py:116`

## Notes
- this PR starts cleanly from upstream `master` and does not depend on `#644` or `review.md`
- the verification blocker is unrelated to this websocket-state fix