### PR TITLE
Migrate docs from mkdocs to zensical

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ test:
 
 docs:
 	cp CHANGELOG.md ./docs/changelog.md
-	mkdocs build
+	zensical build
 
 serve:
 	cp CHANGELOG.md ./docs/changelog.md
-	mkdocs serve
+	zensical serve
 
 publish:
 	cp CHANGELOG.md ./docs/changelog.md

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -1,4 +1,3 @@
-mkdocs>=1.6.1
+zensical
 mkdocstrings[python]>=0.18
-mkdocs-material>=9.4.0
 mkdocs-api-autonav>=0.3.0


### PR DESCRIPTION
Hi Thomas,

wie vorgeschlagen: mkdocs → zensical umgestellt. Zensical ist der Drop-in-Replacement von den mkdocs-material Machern (squidfunk).

Änderungen:
- `requirements_docs.txt`: `mkdocs` + `mkdocs-material` → `zensical` (enthält Material-Theme)
- `Makefile`: `mkdocs build/serve` → `zensical build/serve`
- `publish` bleibt bei `mkdocs gh-deploy` (zensical hat noch kein deploy-Kommando)

Getestet: Baut fehlerfrei, Output ist identisch.

Ref: https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/