### PR TITLE
Fix ELV-SH-SPS25 missing switch entity in HA

### DIFF
--- a/src/homematicip/class_maps.py
+++ b/src/homematicip/class_maps.py
@@ -95,7 +95,7 @@ TYPE_CLASS_MAP = {
     DeviceType.STATUS_BOARD_8: StatusBoard8,
     DeviceType.SWITCH_MEASURING_CABLE_INDOOR: SwitchMeasuring,
     DeviceType.SWITCH_MEASURING_CABLE_OUTDOOR: SwitchMeasuring,
-    DeviceType.SWITCH_POWER_SUPPLY: Switch,
+    DeviceType.SWITCH_POWER_SUPPLY: PlugableSwitch,
     DeviceType.TEMPERATURE_HUMIDITY_SENSOR: TemperatureHumiditySensorWithoutDisplay,
     DeviceType.TEMPERATURE_HUMIDITY_SENSOR_COMPACT: TemperatureHumiditySensorOutdoor,
     DeviceType.TEMPERATURE_HUMIDITY_SENSOR_DISPLAY: TemperatureHumiditySensorDisplay,

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -2133,7 +2133,7 @@ def test_usb_switch_measuring(fake_home: Home):
 def test_switch_power_supply(fake_home: Home):
     with no_ssl_verification():
         d = fake_home.search_device_by_id("3014F7110000000000ELVSPS25")
-        assert isinstance(d, Switch)
+        assert isinstance(d, PlugableSwitch)
         assert d.on is False
         assert d.profileMode == "AUTOMATIC"
         assert d.userDesiredProfileMode == "AUTOMATIC"


### PR DESCRIPTION
The SPS25 was mapped to the base `Switch` class, but HA's `homematicip_cloud` integration only checks for specific subclasses (`PlugableSwitch`, `PrintedCircuitBoardSwitchBattery`, etc.). This caused the device to show up with only a battery entity and no switch.

Map to `PlugableSwitch` instead — functionally identical single-channel battery switch with `SWITCH_CHANNEL`.

Fixes #651