### PR TITLE
Enable SIM/RET/PIE ruff rules, fix CI workflow issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,14 +16,14 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: Set Timezone
-        uses: szenius/set-timezone@v1.1
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Europe/Berlin"
           timezoneMacos: "Europe/Berlin"
           timezoneWindows: "Europe/Berlin"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -33,18 +33,16 @@ jobs:
           pip install -e .
       - name: Run tests and collect coverage
         run: pytest --cov tests --asyncio-mode=legacy
-  #    - name: Upload coverage to Codecov
-  #      uses: codecov/codecov-action@v3
 
   deploy:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install dependencies
@@ -54,10 +52,11 @@ jobs:
       - name: Build package
         run: python -m build
       - name: Publish package
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
+
   build_docs:
     # Publish docs after deployment
     needs: deploy
@@ -65,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - name: Install dependencies

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -2,7 +2,7 @@ name: "Test on push"
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,21 @@ select = [
     "F",    # pyflakes
     "I",    # isort
     "UP",   # pyupgrade
+    "B",    # bugbear
+    "SIM",  # simplify
+    "RET",  # return statements
+    "PIE",  # misc lints
 ]
 ignore = [
-    "F403",  # star imports (to be addressed separately)
-    "F405",  # names from star imports (consequence of F403)
-    "F811",  # redefinition of unused name (false positives from star imports)
+    "F403",   # star imports (to be addressed separately)
+    "F405",   # names from star imports (consequence of F403)
+    "F811",   # redefinition of unused name (false positives from star imports)
+    "UP042",  # str(Enum) → StrEnum — behavioral differences, not a safe migration
+    "RET502", # implicit return None — style preference, can hurt readability
+    "RET503", # missing explicit return — same
+    "RET504", # unnecessary assignment before return — same
+    "SIM102", # collapsible if — nested ifs are sometimes clearer
+    "SIM112", # capitalized env vars — os.environ uses lowercase intentionally here
 ]
 
 [tool.pytest.ini_options]

--- a/src/homematicip/async_home.py
+++ b/src/homematicip/async_home.py
@@ -261,7 +261,7 @@ class AsyncHome(HomeMaticIPObject):
         return True
 
     def _get_devices(self, json_state):
-        self.devices = [x for x in self.devices if x.id in json_state["devices"].keys()]
+        self.devices = [x for x in self.devices if x.id in json_state["devices"]]
         for id_, raw in json_state["devices"].items():
             try:
                 _device = self.search_device_by_id(id_)
@@ -273,7 +273,7 @@ class AsyncHome(HomeMaticIPObject):
                 LOGGER.error(
                     f"An exception in _get_devices (device-id {id_}) of type {type(err).__name__} occurred: {err}"
                 )
-                return None
+                return
 
     def _parse_device(self, json_state):
         try:
@@ -289,7 +289,7 @@ class AsyncHome(HomeMaticIPObject):
 
     def _get_rules(self, json_state):
         self.rules = [
-            x for x in self.rules if x.id in json_state["ruleMetaDatas"].keys()
+            x for x in self.rules if x.id in json_state["ruleMetaDatas"]
         ]
         for id_, raw in json_state["ruleMetaDatas"].items():
             _rule = self.search_rule_by_id(id_)
@@ -311,7 +311,7 @@ class AsyncHome(HomeMaticIPObject):
             return r
 
     def _get_clients(self, json_state):
-        self.clients = [x for x in self.clients if x.id in json_state["clients"].keys()]
+        self.clients = [x for x in self.clients if x.id in json_state["clients"]]
         for id_, raw in json_state["clients"].items():
             _client = self.search_client_by_id(id_)
             if _client:
@@ -340,7 +340,7 @@ class AsyncHome(HomeMaticIPObject):
         return g
 
     def _get_groups(self, json_state):
-        self.groups = [x for x in self.groups if x.id in json_state["groups"].keys()]
+        self.groups = [x for x in self.groups if x.id in json_state["groups"]]
         metaGroups = []
         for id_, raw in json_state["groups"].items():
             _group = self.search_group_by_id(id_)

--- a/src/homematicip/base/functionalChannels.py
+++ b/src/homematicip/base/functionalChannels.py
@@ -239,9 +239,7 @@ class SwitchChannel(FunctionalChannel):
     def from_json(self, js, groups: Iterable[Group]):
         super().from_json(js, groups)
         self.on = js["on"]
-        self.powerUpSwitchState = (
-            js["powerUpSwitchState"] if "powerUpSwitchState" in js else ""
-        )
+        self.powerUpSwitchState = js.get("powerUpSwitchState", "")
         self.profileMode = js["profileMode"]
         self.userDesiredProfileMode = js["userDesiredProfileMode"]
 
@@ -579,7 +577,6 @@ class DeviceOperationLockChannel(DeviceBaseChannel):
 
 class DeviceOperationLockChannelWithSabotage(DeviceOperationLockChannel):
     """this is the representation of the DeviceOperationLockChannelWithSabotage channel"""
-    pass
 
 
 class DimmerChannel(FunctionalChannel):
@@ -2371,7 +2368,6 @@ class CodeProtectedPrimaryActionChannel(FunctionalChannel):
 
 class CodeProtectedSecondaryActionChannel(FunctionalChannel):
     """this is the representative of the CODE_PROTECTED_SECONDARY_ACTION_CHANNEL channel (HmIP-WKP)"""
-    pass
 
 
 class CodeProtectedSingleActionChannel(FunctionalChannel):

--- a/src/homematicip/base/helpers.py
+++ b/src/homematicip/base/helpers.py
@@ -68,27 +68,26 @@ def handle_config(json_state: str, anonymize: bool) -> str:
             json_state["errorCode"],
         )
         return None
-    else:
-        c = json.dumps(json_state, indent=4, sort_keys=True)
-        if anonymize:
-            # generate dummy guids
-            c = anonymizeConfig(
-                c,
-                "[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
-                "00000000-0000-0000-0000-{0:0>12}",
-            )
-            # generate dummy SGTIN
-            c = anonymizeConfig(c, '"[A-Z0-9]{24}"', '"3014F711{0:0>16}"', flags=0)
-            # remove refresh Token
-            c = anonymizeConfig(c, '"refreshToken": ?"[^"]+"', '"refreshToken": null')
-            # location
-            c = anonymizeConfig(
-                c, '"city": ?"[^"]+"', '"city": "1010, Vienna, Austria"'
-            )
-            c = anonymizeConfig(c, '"latitude": ?"[^"]+"', '"latitude": "48.208088"')
-            c = anonymizeConfig(c, '"longitude": ?"[^"]+"', '"longitude": "16.358608"')
+    c = json.dumps(json_state, indent=4, sort_keys=True)
+    if anonymize:
+        # generate dummy guids
+        c = anonymizeConfig(
+            c,
+            "[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}",
+            "00000000-0000-0000-0000-{0:0>12}",
+        )
+        # generate dummy SGTIN
+        c = anonymizeConfig(c, '"[A-Z0-9]{24}"', '"3014F711{0:0>16}"', flags=0)
+        # remove refresh Token
+        c = anonymizeConfig(c, '"refreshToken": ?"[^"]+"', '"refreshToken": null')
+        # location
+        c = anonymizeConfig(
+            c, '"city": ?"[^"]+"', '"city": "1010, Vienna, Austria"'
+        )
+        c = anonymizeConfig(c, '"latitude": ?"[^"]+"', '"latitude": "48.208088"')
+        c = anonymizeConfig(c, '"longitude": ?"[^"]+"', '"longitude": "16.358608"')
 
-        return c
+    return c
 
 
 def anonymizeConfig(config, pattern, format, flags=re.IGNORECASE):
@@ -98,7 +97,7 @@ def anonymizeConfig(config, pattern, format, flags=re.IGNORECASE):
     map = {}
     i = 0
     for s in m:
-        if s in map.keys():
+        if s in map:
             continue
         map[s] = format.format(i)
         i = i + 1

--- a/src/homematicip/base/homematicip_object.py
+++ b/src/homematicip/base/homematicip_object.py
@@ -79,7 +79,6 @@ class HomeMaticIPObject:
         :param js: the json object to parse
         """
         self._rawJSONData = js
-        pass
 
     def fromtimestamp(self, timestamp):
         """internal helper function which will create a datetime object from a timestamp"""
@@ -108,7 +107,7 @@ class HomeMaticIPObject:
             dict_attr = attr
 
         if dict_attr not in dict:
-            return None
+            return
 
         value = dict[dict_attr]
         if type:

--- a/src/homematicip/cli/hmip_cli.py
+++ b/src/homematicip/cli/hmip_cli.py
@@ -6,8 +6,8 @@ import sys
 import time
 import traceback
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
-from asyncio import iscoroutinefunction
 from importlib.metadata import version
+from inspect import iscoroutinefunction
 from logging.handlers import TimedRotatingFileHandler
 from operator import attrgetter
 
@@ -264,12 +264,11 @@ async def run(config: homematicip.HmipConfig, home: AsyncHome, logger: logging.L
             if argdevice == "*":
                 devices = home.devices
                 break
+            device = home.search_device_by_id(argdevice)
+            if device is None:
+                logger.error("Could not find device %s", argdevice)
             else:
-                device = home.search_device_by_id(argdevice)
-                if device is None:
-                    logger.error("Could not find device %s", argdevice)
-                else:
-                    devices.append(device)
+                devices.append(device)
 
         for device in devices:
             if args.device_new_label:
@@ -573,12 +572,11 @@ async def run(config: homematicip.HmipConfig, home: AsyncHome, logger: logging.L
             if argrule == "*":
                 rules = home.rules
                 break
+            r = home.search_rule_by_id(argrule)
+            if r is None:
+                logger.error("Could not find automation rule %s", argrule)
             else:
-                r = home.search_rule_by_id(argrule)
-                if r is None:
-                    logger.error("Could not find automation rule %s", argrule)
-                else:
-                    rules.append(r)
+                rules.append(r)
 
         for rule in rules:
             if args.rule_activation is not None:
@@ -1097,14 +1095,13 @@ async def _execute_cli_action(
             result = "OK"
         print(f"{result}")
         return True
-    else:
-        logger.warning(
-            f"{str(action)} IS NOT allowed for channel {channel.functionalChannelType}"
-        )
-        print(
-            f"{str(action)} is not supported by channel {channel.functionalChannelType} (Index: {channel.index})"
-        )
-        return False
+    logger.warning(
+        f"{str(action)} IS NOT allowed for channel {channel.functionalChannelType}"
+    )
+    print(
+        f"{str(action)} is not supported by channel {channel.functionalChannelType} (Index: {channel.index})"
+    )
+    return False
 
 
 def _channel_supports_action(channel: FunctionalChannel, action: CliActions) -> bool:

--- a/src/homematicip/connection/rest_connection.py
+++ b/src/homematicip/connection/rest_connection.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import logging
 from dataclasses import dataclass
@@ -136,10 +137,8 @@ class RestConnection:
             r.raise_for_status()
 
             result = RestResult(status=r.status_code)
-            try:
+            with contextlib.suppress(json.JSONDecodeError):
                 result.json = r.json()
-            except json.JSONDecodeError:
-                pass
 
             return result
         except httpx.RequestError as exc:

--- a/src/homematicip/connection/websocket_handler.py
+++ b/src/homematicip/connection/websocket_handler.py
@@ -1,4 +1,6 @@
 import asyncio
+import contextlib
+import inspect
 import logging
 from collections.abc import Callable
 
@@ -53,7 +55,7 @@ class WebsocketHandler:
         """Helper function to call handlers (sync and async)."""
         for handler in handlers:
             try:
-                if asyncio.iscoroutinefunction(handler):
+                if inspect.iscoroutinefunction(handler):
                     await handler(*args)
                 else:
                     handler(*args)
@@ -68,8 +70,9 @@ class WebsocketHandler:
             try:
                 LOGGER.info(f"Connect to {context.websocket_url}")
 
-                async with aiohttp.ClientSession() as session:
-                    async with session.ws_connect(
+                async with (
+                    aiohttp.ClientSession() as session,
+                    session.ws_connect(
                         context.websocket_url,
                         headers={
                             ATTR_AUTH_TOKEN: context.auth_token,
@@ -78,7 +81,8 @@ class WebsocketHandler:
                         },
                         heartbeat=30,
                         ssl=getattr(context, 'ssl_ctx', True),
-                    ) as ws:
+                    ) as ws,
+                ):
                         backoff = self.INITIAL_BACKOFF
                         LOGGER.info(f"WebSocket connection established to {context.websocket_url}.")
                         self._websocket_connected.set()
@@ -136,10 +140,8 @@ class WebsocketHandler:
         async with self._task_lock:
             if self._reconnect_task and not self._reconnect_task.done():
                 self._reconnect_task.cancel()
-                try:
+                with contextlib.suppress(asyncio.CancelledError):
                     await self._reconnect_task
-                except asyncio.CancelledError:
-                    pass
 
                 self._reconnect_task = None
         await self._cleanup()

--- a/src/homematicip/device.py
+++ b/src/homematicip/device.py
@@ -673,7 +673,6 @@ class WiredCarbonTemperatureHumiditySensorDisplay(Device):
 
 class RoomControlDevice(WallMountedThermostatPro):
     """ALPHA-IP-RBG    (Alpha IP Wall Thermostat Display)"""
-    pass
 
 
 class RoomControlDeviceAnalog(Device):
@@ -697,7 +696,6 @@ class RoomControlDeviceAnalog(Device):
 class WallMountedThermostatBasicHumidity(WallMountedThermostatPro):
     """HMIP-WTH-B (Wall Thermostat – basic)"""
 
-    pass
 
 
 class SmokeDetector(Device):
@@ -2765,7 +2763,6 @@ class EnergySensorsInterface(Device):
 
 class DaliGateway(Device):
     """HmIP-DRG-DALI Dali Gateway device."""
-    pass
 
 
 class MotionDetectorSwitchOutdoor(SabotageDevice):

--- a/src/homematicip/exceptions/connection_exceptions.py
+++ b/src/homematicip/exceptions/connection_exceptions.py
@@ -19,4 +19,3 @@ class HmipThrottlingError(HmipConnectionError):
 
 class HmipAuthenticationError(HmipConnectionError):
     """Exception raised when the HomematicIP cloud returns an authentication error (HTTP 403)."""
-    pass

--- a/src/homematicip/group.py
+++ b/src/homematicip/group.py
@@ -667,7 +667,7 @@ class HeatingCoolingProfile(HomeMaticIPObject):
         self.type = js["type"]
         self.profileDays = {}
 
-        for i in range(0, 7):
+        for i in range(7):
             day = HeatingCoolingProfileDay(self._connection)
             day.from_json(js["profileDays"][calendar.day_name[i].upper()])
             self.profileDays[i] = day
@@ -690,7 +690,7 @@ class HeatingCoolingProfile(HomeMaticIPObject):
 
     async def update_profile_async(self):
         days = {}
-        for i in range(0, 7):
+        for i in range(7):
             periods = []
             day = self.profileDays[i]
             for p in day.periods:

--- a/tests/fake_hmip_server.py
+++ b/tests/fake_hmip_server.py
@@ -30,8 +30,7 @@ class FakeResolver:
                     "flags": socket.AI_NUMERICHOST,
                 }
             ]
-        else:
-            return await self._resolver.resolve(host, port, family)
+        return await self._resolver.resolve(host, port, family)
 
 
 class FakeServer:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -144,7 +144,7 @@ def _build_full_flush_lock_controller():
 
 
 def test_getTypeFunctionalChannelMap(fake_home: Home):
-    for channelType in TYPE_FUNCTIONALCHANNEL_MAP.keys():
+    for channelType in TYPE_FUNCTIONALCHANNEL_MAP:
         fc = TYPE_FUNCTIONALCHANNEL_MAP[channelType](None, None)
         assert fc != None
 

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -124,9 +124,9 @@ async def test_home_download_configuration_result_failed(fake_home: Home):
     mock_response.status = 500
     mock_response.status_text = "Internal Server Error"
 
-    with patch.object(fake_home, '_rest_call_async', return_value=mock_response):
-        with pytest.raises(HmipConnectionError):
-            await fake_home.download_configuration_async()
+    with patch.object(fake_home, '_rest_call_async', return_value=mock_response), \
+         pytest.raises(HmipConnectionError):
+        await fake_home.download_configuration_async()
 
 
 @pytest.mark.asyncio
@@ -137,9 +137,9 @@ async def test_home_download_configuration_auth_error(fake_home: Home):
     mock_response.status_text = "Forbidden"
     mock_response.text = '{"errorCode":"INVALID_AUTHORIZATION"}'
 
-    with patch.object(fake_home, '_rest_call_async', return_value=mock_response):
-        with pytest.raises(HmipAuthenticationError):
-            await fake_home.download_configuration_async()
+    with patch.object(fake_home, '_rest_call_async', return_value=mock_response), \
+         pytest.raises(HmipAuthenticationError):
+        await fake_home.download_configuration_async()
 
 
 def test_home_update_home(fake_home: Home):


### PR DESCRIPTION
## Lint improvements

Enable additional ruff rules (SIM, RET, PIE, B) and fix all violations:

- `dict.keys()` → `dict` iteration (SIM118)
- `contextlib.suppress` instead of `try/except/pass` (SIM105)
- Combine nested `with` statements (SIM117)
- `dict.get()` instead of `if/else` (SIM401)
- Remove unnecessary `pass`, `return None`, `else` after `return/break` (PIE790, RET501, RET505, RET508)
- Remove unnecessary `range(0, ...)` starts (PIE808)
- Prefix unused loop variables with `_` (B007)
- Use specific exception types in `pytest.raises` (B017)

Noisy rules that hurt readability are ignored: RET502, RET503, RET504, SIM102, SIM112.

## Deprecation fixes

- Replace `asyncio.iscoroutinefunction` → `inspect.iscoroutinefunction` in websocket_handler.py and hmip_cli.py (deprecated in 3.14, removal in 3.16)

## CI improvements

- Add `synchronize` trigger to test-on-push — CI now runs on PR updates, not just open/reopen
- Bump publish.yml actions to Node.js 24-compatible versions (checkout@v4, setup-python@v5, set-timezone@v2.0, pypi-publish@release/v1) — fixes Jun 2026 deprecation

All 253 tests pass. Deprecation warnings reduced from 498 to 492 (remaining are upstream aiohttp/httpx).