### PR TITLE
Harden websocket reconnect handling

### DIFF
--- a/src/homematicip/async_home.py
+++ b/src/homematicip/async_home.py
@@ -662,8 +662,10 @@ class AsyncHome(HomeMaticIPObject):
 
     async def enable_events(self, additional_message_handler: Callable = None):
         """Connect to Websocket and listen for events"""
-        if self._websocket_client and self._websocket_client.is_connected():
-            return
+        if self._websocket_client:
+            if self._websocket_client.is_running():
+                return
+            await self._websocket_client.stop()
 
         self._websocket_client = WebsocketHandler()
         self._websocket_client.add_on_message_handler(self._ws_on_message)
@@ -774,6 +776,36 @@ class AsyncHome(HomeMaticIPObject):
     def websocket_is_connected(self):
         """returns if the websocket is connected."""
         return self._websocket_client.is_connected() if self._websocket_client else False
+
+    def websocket_last_message_time(self) -> float | None:
+        """Returns the loop timestamp of the last received websocket message."""
+        if self._websocket_client is None:
+            return None
+        return self._websocket_client.last_message_time()
+
+    def websocket_message_count(self) -> int:
+        """Returns the number of received websocket messages."""
+        if self._websocket_client is None:
+            return 0
+        return self._websocket_client.message_count()
+
+    def websocket_seconds_since_last_message(self) -> float | None:
+        """Returns the seconds since the last received websocket message."""
+        if self._websocket_client is None:
+            return None
+        return self._websocket_client.seconds_since_last_message()
+
+    def websocket_reconnect_attempt_count(self) -> int:
+        """Returns the number of reconnect attempts in the current outage."""
+        if self._websocket_client is None:
+            return 0
+        return self._websocket_client.reconnect_attempt_count()
+
+    def websocket_last_disconnect_reason(self) -> str | None:
+        """Returns the last websocket disconnect or reconnect reason."""
+        if self._websocket_client is None:
+            return None
+        return self._websocket_client.last_disconnect_reason()
 
     def set_on_connected_handler(self, handler: Callable):
         """Sets a callback that is called when the WebSocket connection is established."""

--- a/src/homematicip/connection/connection_context.py
+++ b/src/homematicip/connection/connection_context.py
@@ -18,7 +18,12 @@ class ConnectionContextBuilder:
                                   auth_token: str | None = None,
                                   enforce_ssl: bool = True,
                                   httpx_client_session: httpx.AsyncClient | None = None,
-                                  ssl_ctx=None):
+                                  ssl_ctx=None,
+                                  websocket_heartbeat_interval: int = 30,
+                                  websocket_connect_timeout: int = 30,
+                                  websocket_message_stale_timeout: int = 28800,
+                                  websocket_initial_backoff: int = 8,
+                                  websocket_max_backoff: int = 900):
         """
         Create a new connection context and lookup urls
 
@@ -35,6 +40,11 @@ class ConnectionContextBuilder:
         ctx.client_auth_token = ClientTokenBuilder.build_client_token(accesspoint_id)
         ctx.ssl_ctx = ssl_ctx
         ctx.enforce_ssl = enforce_ssl
+        ctx.websocket_heartbeat_interval = websocket_heartbeat_interval
+        ctx.websocket_connect_timeout = websocket_connect_timeout
+        ctx.websocket_message_stale_timeout = websocket_message_stale_timeout
+        ctx.websocket_initial_backoff = websocket_initial_backoff
+        ctx.websocket_max_backoff = websocket_max_backoff
 
         cc = ClientCharacteristicsBuilder.get(accesspoint_id)
         ctx.rest_url, ctx.websocket_url = await ConnectionUrlResolver().lookup_urls_async(cc, lookup_url, enforce_ssl,
@@ -50,7 +60,12 @@ class ConnectionContextBuilder:
                       lookup_url: str = "https://lookup.homematic.com:48335/getHost",
                       auth_token: str | None = None,
                       enforce_ssl: bool = True,
-                      ssl_ctx: SSLContext | str | bool | None = None):
+                      ssl_ctx: SSLContext | str | bool | None = None,
+                      websocket_heartbeat_interval: int = 30,
+                      websocket_connect_timeout: int = 30,
+                      websocket_message_stale_timeout: int = 28800,
+                      websocket_initial_backoff: int = 8,
+                      websocket_max_backoff: int = 900):
         """
         Create a new connection context and lookup urls
 
@@ -66,6 +81,11 @@ class ConnectionContextBuilder:
         ctx.client_auth_token = ClientTokenBuilder.build_client_token(accesspoint_id)
         ctx.ssl_ctx = ssl_ctx
         ctx.enforce_ssl = enforce_ssl
+        ctx.websocket_heartbeat_interval = websocket_heartbeat_interval
+        ctx.websocket_connect_timeout = websocket_connect_timeout
+        ctx.websocket_message_stale_timeout = websocket_message_stale_timeout
+        ctx.websocket_initial_backoff = websocket_initial_backoff
+        ctx.websocket_max_backoff = websocket_max_backoff
 
         cc = ClientCharacteristicsBuilder.get(accesspoint_id)
         ctx.rest_url, ctx.websocket_url = ConnectionUrlResolver().lookup_urls(cc, lookup_url, enforce_ssl, ssl_ctx)
@@ -87,3 +107,8 @@ class ConnectionContext:
 
     enforce_ssl: bool = True
     ssl_ctx: SSLContext | str | bool | None = None
+    websocket_heartbeat_interval: int = 30
+    websocket_connect_timeout: int = 30
+    websocket_message_stale_timeout: int = 28800
+    websocket_initial_backoff: int = 8
+    websocket_max_backoff: int = 900

--- a/src/homematicip/connection/websocket_handler.py
+++ b/src/homematicip/connection/websocket_handler.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import inspect
 import logging
+import time
 from collections.abc import Callable
 
 import aiohttp
@@ -95,7 +96,6 @@ class WebsocketHandler:
                     async with ws:
                         backoff = self.INITIAL_BACKOFF
                         self._reconnect_attempt_count = 0
-                        self._last_disconnect_reason = None
                         LOGGER.info(f"WebSocket connection established to {context.websocket_url}.")
                         self._websocket_connected.set()
                         self._disconnect_notified = False
@@ -141,7 +141,7 @@ class WebsocketHandler:
                 break
 
             if msg.type in (aiohttp.WSMsgType.TEXT, aiohttp.WSMsgType.BINARY):
-                self._last_message_time = asyncio.get_running_loop().time()
+                self._last_message_time = time.monotonic()
                 self._message_count += 1
                 await self._handle_ws_message(msg)
             elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED):
@@ -235,7 +235,7 @@ class WebsocketHandler:
         """Returns the seconds since the last WebSocket message was received."""
         if self._last_message_time is None:
             return None
-        return asyncio.get_running_loop().time() - self._last_message_time
+        return time.monotonic() - self._last_message_time
 
     def reconnect_attempt_count(self) -> int:
         """Returns the number of reconnect attempts in the current outage."""

--- a/src/homematicip/connection/websocket_handler.py
+++ b/src/homematicip/connection/websocket_handler.py
@@ -25,11 +25,20 @@ class WebsocketHandler:
 
     def __init__(self):
         self.INITIAL_BACKOFF = 8
+        self.MAX_BACKOFF = 900
+        self.HEARTBEAT_INTERVAL = 30
+        self.CONNECT_TIMEOUT = 30
+        self.MESSAGE_STALE_TIMEOUT = 28800
         self.url = None
         self._stop_event = asyncio.Event()
         self._websocket_connected = asyncio.Event()
         self._reconnect_task = None
         self._task_lock = asyncio.Lock()
+        self._last_message_time: float | None = None
+        self._message_count = 0
+        self._disconnect_notified = True
+        self._reconnect_attempt_count = 0
+        self._last_disconnect_reason: str | None = None
         self._on_message_handlers: list[Callable] = []
         self._on_connected_handler: list[Callable] = []
         self._on_disconnected_handler: list[Callable] = []
@@ -65,52 +74,81 @@ class WebsocketHandler:
 
     async def _connect(self, context: ConnectionContext):
         backoff = self.INITIAL_BACKOFF
-        max_backoff = 900
         while not self._stop_event.is_set():
             try:
                 LOGGER.info(f"Connect to {context.websocket_url}")
 
-                async with (
-                    aiohttp.ClientSession() as session,
-                    session.ws_connect(
-                        context.websocket_url,
-                        headers={
-                            ATTR_AUTH_TOKEN: context.auth_token,
-                            ATTR_CLIENT_AUTH: context.client_auth_token,
-                            ATTR_ACCESSPOINT_ID: context.accesspoint_id
-                        },
-                        heartbeat=30,
-                        ssl=getattr(context, 'ssl_ctx', True),
-                    ) as ws,
-                ):
+                async with aiohttp.ClientSession() as session:
+                    ws = await asyncio.wait_for(
+                        session.ws_connect(
+                            context.websocket_url,
+                            headers={
+                                ATTR_AUTH_TOKEN: context.auth_token,
+                                ATTR_CLIENT_AUTH: context.client_auth_token,
+                                ATTR_ACCESSPOINT_ID: context.accesspoint_id
+                            },
+                            heartbeat=self.HEARTBEAT_INTERVAL,
+                            ssl=getattr(context, 'ssl_ctx', True),
+                        ),
+                        timeout=self.CONNECT_TIMEOUT,
+                    )
+                    async with ws:
                         backoff = self.INITIAL_BACKOFF
+                        self._reconnect_attempt_count = 0
+                        self._last_disconnect_reason = None
                         LOGGER.info(f"WebSocket connection established to {context.websocket_url}.")
                         self._websocket_connected.set()
+                        self._disconnect_notified = False
                         await self._call_handlers(self._on_connected_handler)
                         await self._listen(ws)
 
-            except Exception as e:
-                self._websocket_connected.clear()
-                reason = f"Websocket lost connection: {e}. Retry in {backoff}s."
-                LOGGER.warning(reason)
-
-                try:
-                    await self._call_handlers(self._on_reconnect_handler, reason)
-                except Exception as handler_error:
-                    LOGGER.error(f"Error in reconnect handler: {handler_error}", exc_info=True)
-
+            except TimeoutError:
+                reason = (
+                    f"Websocket connect timed out after {self.CONNECT_TIMEOUT}s. "
+                    f"Retry in {backoff}s."
+                )
+                await self._handle_reconnect(reason)
                 await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, max_backoff)
+                backoff = min(backoff * 2, self.MAX_BACKOFF)
+            except Exception as e:
+                reason = f"Websocket lost connection: {e}. Retry in {backoff}s."
+                await self._handle_reconnect(reason)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, self.MAX_BACKOFF)
             finally:
                 await self._cleanup()
 
 
     async def _listen(self, ws):
-        async for msg in ws:
+        while not self._stop_event.is_set():
+            try:
+                msg = await asyncio.wait_for(
+                    ws.receive(),
+                    timeout=self.MESSAGE_STALE_TIMEOUT,
+                )
+            except TimeoutError:
+                reason = (
+                    "No HomematicIP websocket events received for "
+                    f"{self.MESSAGE_STALE_TIMEOUT} seconds despite an open connection. "
+                    "Forcing reconnect as a stale-connection safety net."
+                )
+                LOGGER.warning(reason)
+                await ws.close(
+                    code=aiohttp.WSCloseCode.GOING_AWAY,
+                    message=b"Stale connection safety net",
+                )
+                self._last_disconnect_reason = reason
+                break
+
             if msg.type in (aiohttp.WSMsgType.TEXT, aiohttp.WSMsgType.BINARY):
+                self._last_message_time = asyncio.get_running_loop().time()
+                self._message_count += 1
                 await self._handle_ws_message(msg)
+            elif msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED):
+                LOGGER.info("WebSocket closed by server.")
+                break
             elif msg.type == aiohttp.WSMsgType.ERROR:
-                LOGGER.error(f"Error in websocket: {msg}")
+                LOGGER.error("Error in websocket: %s", msg)
                 break
 
     async def _handle_ws_message(self, message: WSMessage):
@@ -120,15 +158,37 @@ class WebsocketHandler:
             LOGGER.error(f"Error handling message: {e}", exc_info=True)
 
     async def _cleanup(self):
+        if self._disconnect_notified:
+            return
+        self._disconnect_notified = True
         self._websocket_connected.clear()
         await self._call_handlers(self._on_disconnected_handler)
+
+    async def _handle_reconnect(self, reason: str):
+        self._websocket_connected.clear()
+        self._reconnect_attempt_count += 1
+        self._last_disconnect_reason = reason
+        LOGGER.warning(reason)
+
+        try:
+            await self._call_handlers(self._on_reconnect_handler, reason)
+        except Exception as handler_error:
+            LOGGER.error(f"Error in reconnect handler: {handler_error}", exc_info=True)
+
+    def _apply_context_settings(self, context: ConnectionContext):
+        self.HEARTBEAT_INTERVAL = context.websocket_heartbeat_interval
+        self.CONNECT_TIMEOUT = context.websocket_connect_timeout
+        self.MESSAGE_STALE_TIMEOUT = context.websocket_message_stale_timeout
+        self.INITIAL_BACKOFF = context.websocket_initial_backoff
+        self.MAX_BACKOFF = context.websocket_max_backoff
 
     async def start(self, context: ConnectionContext):
         async with self._task_lock:
             LOGGER.info("Start websocket client...")
-            if self._reconnect_task and not self._reconnect_task.done():
-                LOGGER.info("Already connected.")
+            if self.is_running():
+                LOGGER.info("WebSocket client is already running.")
                 return
+            self._apply_context_settings(context)
             self._stop_event.clear()
             self._reconnect_task = asyncio.create_task(self._connect(context))
             self._reconnect_task.add_done_callback(self._handle_task_result)
@@ -158,3 +218,29 @@ class WebsocketHandler:
     def is_connected(self):
         """Returns True if the WebSocket connection is active."""
         return self._websocket_connected.is_set()
+
+    def is_running(self) -> bool:
+        """Returns True if the reconnect loop is currently running."""
+        return self._reconnect_task is not None and not self._reconnect_task.done()
+
+    def last_message_time(self) -> float | None:
+        """Returns the loop timestamp of the last received WebSocket message."""
+        return self._last_message_time
+
+    def message_count(self) -> int:
+        """Returns the number of WebSocket messages received in this session."""
+        return self._message_count
+
+    def seconds_since_last_message(self) -> float | None:
+        """Returns the seconds since the last WebSocket message was received."""
+        if self._last_message_time is None:
+            return None
+        return asyncio.get_running_loop().time() - self._last_message_time
+
+    def reconnect_attempt_count(self) -> int:
+        """Returns the number of reconnect attempts in the current outage."""
+        return self._reconnect_attempt_count
+
+    def last_disconnect_reason(self) -> str | None:
+        """Returns the last recorded disconnect or reconnect reason."""
+        return self._last_disconnect_reason

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,14 +99,19 @@ async def fake_cloud(aiohttp_server, ssl_ctx, session_stop_threads):
         app.router.add_route("GET", "/{tail:.*}", aio_server)
         app.router.add_route("POST", "/{tail:.*}", aio_server)
 
-        test_server = TestServer(app)
-        asyncio.run_coroutine_threadsafe(
-            test_server.start_server(loop=session_stop_threads, ssl=ssl_ctx),
-            session_stop_threads,
-        ).result()
-        aio_server.url = str(test_server._root)
-        test_server.url = aio_server.url
-        test_server.aio_server = aio_server
+        server = TestServer(app)
+        try:
+            asyncio.run_coroutine_threadsafe(
+                server.start_server(loop=session_stop_threads, ssl=ssl_ctx),
+                session_stop_threads,
+            ).result()
+        except Exception:
+            test_server = None
+            raise
+        aio_server.url = str(server._root)
+        server.url = aio_server.url
+        server.aio_server = aio_server
+        test_server = server
     test_server.aio_server.reset()
     return test_server
 

--- a/tests/connection/test_connection_context.py
+++ b/tests/connection/test_connection_context.py
@@ -44,3 +44,32 @@ async def test_build_context_without_client_session(mocker):
     assert context.rest_url == "https://example.com/rest"
     assert context.websocket_url == "wss://example.com/ws"
     assert context.accesspoint_id == "access_point_id"
+
+
+@pytest.mark.asyncio
+async def test_build_context_carries_websocket_settings(mocker):
+    response = mocker.Mock(spec=httpx.Response)
+    response.status_code = 200
+    response.json.return_value = {
+        "urlREST": "https://example.com/rest",
+        "urlWebSocket": "wss://example.com/ws",
+    }
+
+    patched = mocker.patch("homematicip.connection.connection_context.httpx.AsyncClient.post")
+    patched.return_value = response
+
+    context = await ConnectionContextBuilder.build_context_async(
+        "access_point_id",
+        "https://example.com/lookup",
+        websocket_heartbeat_interval=15,
+        websocket_connect_timeout=12,
+        websocket_message_stale_timeout=90,
+        websocket_initial_backoff=3,
+        websocket_max_backoff=111,
+    )
+
+    assert context.websocket_heartbeat_interval == 15
+    assert context.websocket_connect_timeout == 12
+    assert context.websocket_message_stale_timeout == 90
+    assert context.websocket_initial_backoff == 3
+    assert context.websocket_max_backoff == 111

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -768,9 +768,12 @@ async def test_websocket_channel_event(fake_home: Home):
 
 
 @pytest.mark.asyncio
-async def test_enable_events(fake_home):
+async def test_enable_events():
+    fake_home = Home()
+    fake_home._connection_context = Mock(spec=ConnectionContext)
     mock_websocket_handler = Mock()
     mock_websocket_handler.start = AsyncMock()
+    mock_websocket_handler.is_running.return_value = False
     mock_additional_handler = AsyncMock()
 
     with patch('homematicip.async_home.WebsocketHandler', return_value=mock_websocket_handler):
@@ -782,32 +785,39 @@ async def test_enable_events(fake_home):
 
 
 @pytest.mark.asyncio
-async def test_enable_events_active(fake_home):
+async def test_enable_events_active():
+    fake_home = Home()
     fake_home._websocket_client = Mock()
-    fake_home._websocket_client.is_connected.return_value = True
+    fake_home._websocket_client.is_running.return_value = True
     await fake_home.enable_events()
 
     assert not fake_home._websocket_client.start.called
 
 
 @pytest.mark.asyncio
-async def test_enable_events_reconnects_when_client_exists_but_is_disconnected(fake_home):
+async def test_enable_events_reconnects_when_client_exists_but_is_disconnected():
+    fake_home = Home()
+    fake_home._connection_context = Mock(spec=ConnectionContext)
     stale_websocket_handler = Mock()
-    stale_websocket_handler.is_connected.return_value = False
+    stale_websocket_handler.is_running.return_value = False
+    stale_websocket_handler.stop = AsyncMock()
     fake_home._websocket_client = stale_websocket_handler
 
     new_websocket_handler = Mock()
     new_websocket_handler.start = AsyncMock()
+    new_websocket_handler.is_running.return_value = False
 
     with patch('homematicip.async_home.WebsocketHandler', return_value=new_websocket_handler):
         await fake_home.enable_events()
 
+    stale_websocket_handler.stop.assert_awaited_once()
     assert fake_home._websocket_client is new_websocket_handler
     new_websocket_handler.start.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_disable_events(fake_home):
+async def test_disable_events():
+    fake_home = Home()
     fake_client = AsyncMock()
     fake_home._websocket_client = fake_client
     await fake_home.disable_events_async()
@@ -816,10 +826,33 @@ async def test_disable_events(fake_home):
     assert fake_client.stop.called
 
 
-def test_websocket_is_connected_returns_bool(fake_home):
+def test_websocket_is_connected_returns_bool():
+    fake_home = Home()
     assert fake_home.websocket_is_connected() is False
 
     fake_home._websocket_client = Mock()
     fake_home._websocket_client.is_connected.return_value = True
 
     assert fake_home.websocket_is_connected() is True
+
+
+def test_websocket_message_metrics_wrappers():
+    fake_home = Home()
+    assert fake_home.websocket_last_message_time() is None
+    assert fake_home.websocket_message_count() == 0
+    assert fake_home.websocket_seconds_since_last_message() is None
+    assert fake_home.websocket_reconnect_attempt_count() == 0
+    assert fake_home.websocket_last_disconnect_reason() is None
+
+    fake_home._websocket_client = Mock()
+    fake_home._websocket_client.last_message_time.return_value = 123.0
+    fake_home._websocket_client.message_count.return_value = 7
+    fake_home._websocket_client.seconds_since_last_message.return_value = 4.5
+    fake_home._websocket_client.reconnect_attempt_count.return_value = 2
+    fake_home._websocket_client.last_disconnect_reason.return_value = "idle timeout"
+
+    assert fake_home.websocket_last_message_time() == 123.0
+    assert fake_home.websocket_message_count() == 7
+    assert fake_home.websocket_seconds_since_last_message() == 4.5
+    assert fake_home.websocket_reconnect_attempt_count() == 2
+    assert fake_home.websocket_last_disconnect_reason() == "idle timeout"

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -214,3 +215,13 @@ async def test_handle_reconnect_updates_reason_and_attempt_count():
 
     assert client.reconnect_attempt_count() == 1
     assert client.last_disconnect_reason() == "connection dropped"
+
+
+def test_seconds_since_last_message_works_without_running_loop():
+    client = WebsocketHandler()
+    client._last_message_time = time.monotonic() - 5
+
+    elapsed = client.seconds_since_last_message()
+
+    assert elapsed is not None
+    assert 0 < elapsed < 60

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -190,7 +190,7 @@ async def test_listen_stale_timeout_triggers_close_and_warning(monkeypatch, capl
     monkeypatch.setattr(
         asyncio,
         "wait_for",
-        AsyncMock(side_effect=asyncio.TimeoutError()),
+        AsyncMock(side_effect=TimeoutError()),
     )
 
     with caplog.at_level("WARNING"):

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
@@ -11,6 +11,15 @@ class DummyMsg:
     def __init__(self, data, type_):
         self.data = data
         self.type = type_
+
+
+def _receive_side_effect(messages):
+    pending = list(messages)
+
+    async def _receive():
+        return pending.pop(0)
+
+    return _receive
 
 
 @pytest.mark.asyncio
@@ -28,38 +37,47 @@ async def test_is_connected_false_initial():
 
 
 @pytest.mark.asyncio
-async def test_is_connected_true(monkeypatch):
+async def test_is_connected_true():
     client = WebsocketHandler()
     client._websocket_connected.set()
     assert client.is_connected()
+
+
+@pytest.mark.asyncio
+async def test_is_running_false_initial():
+    client = WebsocketHandler()
+    assert not client.is_running()
+
 
 @pytest.mark.asyncio
 async def test_handle_task_result_logs_cancelled(caplog):
     client = WebsocketHandler()
     task = MagicMock()
     task.result.side_effect = asyncio.CancelledError()
-    with caplog.at_level('INFO'):
+    with caplog.at_level("INFO"):
         client._handle_task_result(task)
-    assert any('cancelled' in m for m in caplog.text.splitlines())
+    assert any("cancelled" in message for message in caplog.text.splitlines())
 
 
 @pytest.mark.asyncio
 async def test_handle_task_result_logs_exception(caplog):
     client = WebsocketHandler()
     task = MagicMock()
-    task.result.side_effect = Exception('fail')
-    with caplog.at_level('ERROR'):
+    task.result.side_effect = Exception("fail")
+    with caplog.at_level("ERROR"):
         client._handle_task_result(task)
-    assert any('Error in reconnect' in m for m in caplog.text.splitlines())
+    assert any("Error in reconnect" in message for message in caplog.text.splitlines())
 
 
 @pytest.mark.asyncio
-async def test_cleanup_closes_ws_and_session(monkeypatch):
+async def test_cleanup_closes_ws_and_session():
     callback_mock = AsyncMock()
     client = WebsocketHandler()
     client._websocket_connected.set()
+    client._disconnect_notified = False
     client.add_on_disconnected_handler(callback_mock)
 
+    await client._cleanup()
     await client._cleanup()
 
     assert not client._websocket_connected.is_set()
@@ -70,25 +88,129 @@ async def test_cleanup_closes_ws_and_session(monkeypatch):
 async def test_start_and_stop(monkeypatch):
     client = WebsocketHandler()
     context = MagicMock()
-    monkeypatch.setattr(client, '_connect', AsyncMock())
+    monkeypatch.setattr(client, "_connect", AsyncMock())
     await client.start(context)
     assert client._reconnect_task is not None
+    assert client.is_running()
     await client.stop()
     assert client._reconnect_task is None
 
 
 @pytest.mark.asyncio
-async def test_listen_calls_handlers(monkeypatch):
+async def test_start_applies_context_settings(monkeypatch):
+    client = WebsocketHandler()
+    context = MagicMock()
+    context.websocket_heartbeat_interval = 11
+    context.websocket_connect_timeout = 22
+    context.websocket_message_stale_timeout = 33
+    context.websocket_initial_backoff = 4
+    context.websocket_max_backoff = 55
+    monkeypatch.setattr(client, "_connect", AsyncMock())
+
+    await client.start(context)
+
+    assert client.HEARTBEAT_INTERVAL == 11
+    assert client.CONNECT_TIMEOUT == 22
+    assert client.MESSAGE_STALE_TIMEOUT == 33
+    assert client.INITIAL_BACKOFF == 4
+    assert client.MAX_BACKOFF == 55
+
+
+@pytest.mark.asyncio
+async def test_listen_calls_handlers():
     client = WebsocketHandler()
     handler = AsyncMock()
     client.add_on_message_handler(handler)
     ws_mock = MagicMock()
-    ws_mock.__aiter__.return_value = [
-        DummyMsg('test', type_=aiohttp.WSMsgType.TEXT),
-        DummyMsg('test2', type_=aiohttp.WSMsgType.BINARY),
-        DummyMsg('err', type_=aiohttp.WSMsgType.ERROR)
-    ]
-    with patch('logging.Logger.debug'), patch('logging.Logger.error'):
+    ws_mock.receive = AsyncMock(
+        side_effect=_receive_side_effect(
+            [
+                DummyMsg("test", type_=aiohttp.WSMsgType.TEXT),
+                DummyMsg("test2", type_=aiohttp.WSMsgType.BINARY),
+                DummyMsg("err", type_=aiohttp.WSMsgType.ERROR),
+            ]
+        )
+    )
+
+    await client._listen(ws_mock)
+
+    handler.assert_any_await("test")
+    handler.assert_any_await("test2")
+    assert client.message_count() == 2
+    assert client.last_message_time() is not None
+
+
+@pytest.mark.asyncio
+async def test_listen_stops_on_close_without_calling_handlers():
+    client = WebsocketHandler()
+    handler = AsyncMock()
+    client.add_on_message_handler(handler)
+
+    ws_mock = MagicMock()
+    ws_mock.receive = AsyncMock(
+        side_effect=_receive_side_effect(
+            [
+                DummyMsg(None, type_=aiohttp.WSMsgType.CLOSE),
+                DummyMsg("after", type_=aiohttp.WSMsgType.TEXT),
+            ]
+        )
+    )
+
+    await client._listen(ws_mock)
+
+    handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_listen_logs_error_on_error_message(caplog):
+    client = WebsocketHandler()
+    ws_mock = MagicMock()
+    ws_mock.receive = AsyncMock(
+        side_effect=_receive_side_effect(
+            [
+                DummyMsg("bad", type_=aiohttp.WSMsgType.ERROR),
+            ]
+        )
+    )
+
+    with caplog.at_level("ERROR"):
         await client._listen(ws_mock)
-    handler.assert_any_await('test')
-    handler.assert_any_await('test2')
+
+    assert "Error in websocket" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_listen_stale_timeout_triggers_close_and_warning(monkeypatch, caplog):
+    client = WebsocketHandler()
+
+    ws_mock = MagicMock()
+    ws_mock.close = AsyncMock()
+
+    monkeypatch.setattr(
+        asyncio,
+        "wait_for",
+        AsyncMock(side_effect=asyncio.TimeoutError()),
+    )
+
+    with caplog.at_level("WARNING"):
+        await client._listen(ws_mock)
+
+    ws_mock.close.assert_awaited_once()
+    assert "stale-connection safety net" in caplog.text
+    assert "No HomematicIP websocket events received" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_seconds_since_last_message_returns_none_without_messages():
+    client = WebsocketHandler()
+    assert client.seconds_since_last_message() is None
+
+
+@pytest.mark.asyncio
+async def test_handle_reconnect_updates_reason_and_attempt_count():
+    client = WebsocketHandler()
+
+    await client._handle_reconnect("connection dropped")
+
+    assert client.reconnect_attempt_count() == 1
+    assert client.last_disconnect_reason() == "connection dropped"


### PR DESCRIPTION
## Summary

Addresses nightly connection losses where HA does not recover (home-assistant/core#160048, home-assistant/core#166688).

**Connection robustness:**
- Add connect timeout (30s) to prevent hanging on `ws_connect`
- Handle `CLOSE`/`CLOSED` WebSocket messages explicitly in listen loop
- Add stale connection timeout (8h) as last-resort fallback when heartbeat mechanism fails silently
- Guard `_cleanup` against duplicate disconnect handler calls
- `enable_events()` checks `is_running()` (loop alive) instead of `is_connected()` (socket open), properly stops stale client before creating new one

**Reconnect improvements:**
- Extract `_handle_reconnect()` to consolidate reconnect logic
- Track reconnect attempt count, reset on successful connection
- Separate `TimeoutError` handling with specific log message

**Configurability:**
- All websocket timing parameters (heartbeat, connect timeout, stale timeout, backoff) configurable via `ConnectionContext`
- Allows HA to tune values without library changes

**Diagnostics:**
- `last_message_time()`, `message_count()`, `seconds_since_last_message()`
- `reconnect_attempt_count()`, `last_disconnect_reason()`
- Wrappers on `AsyncHome` for easy access from HA

**Housekeeping:**
- Replace deprecated `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction`
- Fix conftest test-fixture initialization to prevent cascading failures
- Decouple websocket lifecycle tests from fake-cloud fixture

## Test plan
- All new and existing websocket tests pass
- Idle timeout, close handling, reconnect tracking covered by dedicated tests
- `test_init` failure is pre-existing (Python 3.14 event loop deprecation), not related