### PR TITLE
Fix docs publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,10 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements_docs.txt
           pip install -e .
-      - name: Build and deploy documentation
-        run: |
-          make publish
+      - name: Build documentation
+        run: make publish
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ serve:
 
 publish:
 	cp CHANGELOG.md ./docs/changelog.md
-	zensical gh-deploy --force
+	zensical build
 
 clean:
 	rm -rf site


### PR DESCRIPTION
## What

Fix the docs publish step that has been failing since the mkdocs → zensical migration in #647.

## Why

PR #647 swapped `mkdocs build`/`mkdocs serve` for `zensical build`/`zensical serve`, but missed the `publish:` Makefile target which still uses `zensical gh-deploy --force`. zensical has no `gh-deploy` subcommand (only `build`, `new`, `serve`), so every release run since 2.8.0 has failed at the docs step. PyPI deployment is unaffected, but [the published docs](https://hahn-th.github.io/homematicip-rest-api/) are stale.

## How

- `Makefile`: change `publish:` to `zensical build` (writes to `site/`)
- `.github/workflows/publish.yml`: add `peaceiris/actions-gh-pages@v4` step to deploy `site/` to the `gh-pages` branch

Verified locally: `zensical build` produces a valid `site/` directory.