### PR TITLE
Add websocket staleness detection with configurable thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED](https://github.com/hahn-th/homematicip-rest-api/compare/2.9.0..master)
 
+### Added
+
+- Add websocket staleness detection: configurable warning (5m) and error (30m) thresholds fire registered handlers when the websocket reports connected but has gone silent. Register via `home.set_on_websocket_stale_handler(handler)`. Complements the existing 8h `MESSAGE_STALE_TIMEOUT` reconnect safety net by surfacing the condition much earlier.
+
 ## [2.9.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.8.0..2.9.0)
 
 ### Added

--- a/src/homematicip/async_home.py
+++ b/src/homematicip/async_home.py
@@ -822,3 +822,13 @@ class AsyncHome(HomeMaticIPObject):
         after a disconnect."""
         if self._websocket_client:
             self._websocket_client.add_on_reconnect_handler(handler)
+
+    def set_on_websocket_stale_handler(self, handler: Callable):
+        """Sets a callback that is called when the WebSocket reports connected
+        but has not received a message past the configured thresholds.
+
+        Handler signature: ``handler(severity: str, seconds_since: float)``.
+        See :meth:`WebsocketHandler.add_on_stale_handler` for details.
+        """
+        if self._websocket_client:
+            self._websocket_client.add_on_stale_handler(handler)

--- a/src/homematicip/connection/websocket_handler.py
+++ b/src/homematicip/connection/websocket_handler.py
@@ -30,20 +30,30 @@ class WebsocketHandler:
         self.HEARTBEAT_INTERVAL = 30
         self.CONNECT_TIMEOUT = 30
         self.MESSAGE_STALE_TIMEOUT = 28800
+        # Staleness early-warning thresholds. The MESSAGE_STALE_TIMEOUT
+        # safety net only forces a reconnect after 8h; these fire much
+        # earlier so consumers can surface the condition to users.
+        self.STALE_CHECK_INTERVAL = 60
+        self.STALE_WARNING_SECONDS = 300
+        self.STALE_ERROR_SECONDS = 1800
         self.url = None
         self._stop_event = asyncio.Event()
         self._websocket_connected = asyncio.Event()
         self._reconnect_task = None
+        self._staleness_task: asyncio.Task | None = None
         self._task_lock = asyncio.Lock()
         self._last_message_time: float | None = None
         self._message_count = 0
         self._disconnect_notified = True
         self._reconnect_attempt_count = 0
         self._last_disconnect_reason: str | None = None
+        self._stale_warning_fired = False
+        self._stale_error_fired = False
         self._on_message_handlers: list[Callable] = []
         self._on_connected_handler: list[Callable] = []
         self._on_disconnected_handler: list[Callable] = []
         self._on_reconnect_handler: list[Callable] = []
+        self._on_stale_handler: list[Callable] = []
 
     def add_on_connected_handler(self, handler: Callable):
         """Adds a handler that is called when the connection is established."""
@@ -60,6 +70,47 @@ class WebsocketHandler:
     def add_on_message_handler(self, handler: Callable):
         """Adds a handler for incoming messages."""
         self._on_message_handlers.append(handler)
+
+    def add_on_stale_handler(self, handler: Callable):
+        """Adds a handler called when the websocket reports connected but has
+        gone silent past the configured thresholds.
+
+        Handler signature: ``handler(severity: str, seconds_since: float)``
+        where ``severity`` is ``"warning"`` (>= STALE_WARNING_SECONDS) or
+        ``"error"`` (>= STALE_ERROR_SECONDS). Each severity fires at most
+        once per staleness episode and resets when a fresh message arrives.
+        """
+        self._on_stale_handler.append(handler)
+
+    async def _staleness_monitor(self):
+        """Periodically check for a connected-but-silent websocket and fire
+        on_stale handlers when warning/error thresholds are crossed."""
+        while not self._stop_event.is_set():
+            try:
+                await asyncio.sleep(self.STALE_CHECK_INTERVAL)
+            except asyncio.CancelledError:
+                break
+            if not self.is_connected():
+                continue
+            seconds_since = self.seconds_since_last_message()
+            if seconds_since is None:
+                continue
+            if seconds_since < self.STALE_WARNING_SECONDS:
+                self._stale_warning_fired = False
+                self._stale_error_fired = False
+                continue
+            if seconds_since >= self.STALE_ERROR_SECONDS:
+                if not self._stale_error_fired:
+                    await self._call_handlers(
+                        self._on_stale_handler, "error", seconds_since
+                    )
+                    self._stale_error_fired = True
+                continue
+            if not self._stale_warning_fired:
+                await self._call_handlers(
+                    self._on_stale_handler, "warning", seconds_since
+                )
+                self._stale_warning_fired = True
 
     async def _call_handlers(self, handlers, *args):
         """Helper function to call handlers (sync and async)."""
@@ -192,6 +243,7 @@ class WebsocketHandler:
             self._stop_event.clear()
             self._reconnect_task = asyncio.create_task(self._connect(context))
             self._reconnect_task.add_done_callback(self._handle_task_result)
+            self._staleness_task = asyncio.create_task(self._staleness_monitor())
             LOGGER.info("Connect task started.")
 
     async def stop(self):
@@ -204,6 +256,11 @@ class WebsocketHandler:
                     await self._reconnect_task
 
                 self._reconnect_task = None
+            if self._staleness_task and not self._staleness_task.done():
+                self._staleness_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._staleness_task
+                self._staleness_task = None
         await self._cleanup()
         LOGGER.info("[Stop] WebSocket client stopped.")
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import time
 from unittest.mock import AsyncMock, MagicMock
 
@@ -225,3 +226,119 @@ def test_seconds_since_last_message_works_without_running_loop():
 
     assert elapsed is not None
     assert 0 < elapsed < 60
+
+
+@pytest.mark.asyncio
+async def test_add_on_stale_handler_registers():
+    client = WebsocketHandler()
+    handler = MagicMock()
+    client.add_on_stale_handler(handler)
+    assert handler in client._on_stale_handler
+
+
+@pytest.mark.asyncio
+async def test_staleness_monitor_skips_when_disconnected():
+    """No fire when not connected, even if last_message_time is old."""
+    client = WebsocketHandler()
+    client.STALE_CHECK_INTERVAL = 0.01
+    client.STALE_WARNING_SECONDS = 1
+    handler = MagicMock()
+    client.add_on_stale_handler(handler)
+    client._last_message_time = time.monotonic() - 100  # very stale
+    # Note: _websocket_connected is NOT set
+
+    task = asyncio.create_task(client._staleness_monitor())
+    await asyncio.sleep(0.05)
+    client._stop_event.set()
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+    handler.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_staleness_monitor_fires_warning_then_error():
+    client = WebsocketHandler()
+    client.STALE_CHECK_INTERVAL = 0.01
+    client.STALE_WARNING_SECONDS = 1
+    client.STALE_ERROR_SECONDS = 5
+    handler = MagicMock()
+    client.add_on_stale_handler(handler)
+    client._websocket_connected.set()
+    # 2s stale: above warning, below error
+    client._last_message_time = time.monotonic() - 2
+
+    task = asyncio.create_task(client._staleness_monitor())
+    await asyncio.sleep(0.05)
+
+    handler.assert_called_once()
+    args = handler.call_args[0]
+    assert args[0] == "warning"
+    assert args[1] >= 1
+
+    # Now bump to error severity
+    handler.reset_mock()
+    client._last_message_time = time.monotonic() - 6
+    await asyncio.sleep(0.05)
+
+    handler.assert_called_once()
+    assert handler.call_args[0][0] == "error"
+
+    client._stop_event.set()
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_staleness_monitor_does_not_refire_same_severity():
+    client = WebsocketHandler()
+    client.STALE_CHECK_INTERVAL = 0.01
+    client.STALE_WARNING_SECONDS = 1
+    client.STALE_ERROR_SECONDS = 100
+    handler = MagicMock()
+    client.add_on_stale_handler(handler)
+    client._websocket_connected.set()
+    client._last_message_time = time.monotonic() - 2
+
+    task = asyncio.create_task(client._staleness_monitor())
+    await asyncio.sleep(0.1)  # multiple check cycles
+
+    handler.assert_called_once()  # still only one call
+
+    client._stop_event.set()
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_staleness_monitor_resets_on_fresh_message():
+    client = WebsocketHandler()
+    client.STALE_CHECK_INTERVAL = 0.01
+    client.STALE_WARNING_SECONDS = 1
+    client.STALE_ERROR_SECONDS = 100
+    handler = MagicMock()
+    client.add_on_stale_handler(handler)
+    client._websocket_connected.set()
+    client._last_message_time = time.monotonic() - 2
+
+    task = asyncio.create_task(client._staleness_monitor())
+    await asyncio.sleep(0.05)
+    handler.assert_called_once()
+
+    # Fresh message arrives
+    client._last_message_time = time.monotonic()
+    await asyncio.sleep(0.05)
+    handler.reset_mock()
+
+    # Go stale again
+    client._last_message_time = time.monotonic() - 2
+    await asyncio.sleep(0.05)
+    handler.assert_called_once()  # fired again after reset
+
+    client._stop_event.set()
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task


### PR DESCRIPTION
## Summary

Adds websocket staleness detection complementary to the existing 8h `MESSAGE_STALE_TIMEOUT` safety net. The library runs a periodic check (every 60s) while connected, and fires registered `on_stale` handlers when the websocket reports connected but no messages have arrived past warning (5m) or error (30m) thresholds.

This is the library-side fix for [home-assistant/core#169526](https://github.com/home-assistant/core/pull/169526), where edenhaus correctly pointed out that staleness threshold logic belongs in the library (the library knows the keepalive cadence, not HA).

## API

```python
from homematicip.async_home import AsyncHome

home: AsyncHome = ...

def on_stale(severity: str, seconds_since: float) -> None:
    # severity = "warning" or "error"
    print(f"WS stale ({severity}): {seconds_since:.0f}s")

home.set_on_websocket_stale_handler(on_stale)
```

Each severity fires at most once per staleness episode and resets when a fresh message arrives.

## Thresholds

Configured as `WebsocketHandler` instance attributes (with sensible defaults):

- `STALE_CHECK_INTERVAL = 60` (how often to check, in seconds)
- `STALE_WARNING_SECONDS = 300` (5 min)
- `STALE_ERROR_SECONDS = 1800` (30 min)

## Tests

5 new tests covering registration, no-fire-when-disconnected, warning then error escalation, no-re-fire of same severity per episode, and reset on fresh message.

All tests pass; ruff clean.

## Changelog

Entry added under `[UNRELEASED]`.
