### PR TITLE
Add post-reconnect recovery helpers on AsyncHome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `AsyncHome.get_current_state_async_with_retry()`: refreshes state with exponential backoff retry for use in long-running clients (e.g. Home Assistant post-reconnect recovery). Re-raises `HmipAuthenticationError` and `asyncio.CancelledError` immediately; retries on connection errors and unforeseen exceptions. Lets callers move retry orchestration out of integration code and into the library.
+- Add post-reconnect recovery helpers on `AsyncHome` so long-running clients (e.g. Home Assistant) can move reconnect orchestration out of integration code:
+  - `wait_for_websocket_connection_async(timeout, poll_interval, warning_threshold)`: best-effort bounded wait for `websocket_is_connected()` to become `True`, with a configurable warning log if the connection takes longer than expected. Returns `True` on success, `False` on timeout.
+  - `get_current_state_async_with_retry(initial_delay, max_delay)`: exponential-backoff retry around `get_current_state_async`. Re-raises `HmipAuthenticationError`, `HomeNotInitializedError`, and `asyncio.CancelledError` immediately; retries on `HmipConnectionError` and unforeseen exceptions.
+  - `refresh_state_after_reconnect_async(...)`: convenience wrapper that performs the websocket wait followed by the retrying state refresh in one call.
 
 ## [2.10.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.9.0..2.10.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED](https://github.com/hahn-th/homematicip-rest-api/compare/2.10.0..master)
 
+### Added
+
+- Add `AsyncHome.get_current_state_async_with_retry()`: refreshes state with exponential backoff retry for use in long-running clients (e.g. Home Assistant post-reconnect recovery). Re-raises `HmipAuthenticationError` and `asyncio.CancelledError` immediately; retries on connection errors and unforeseen exceptions. Lets callers move retry orchestration out of integration code and into the library.
+
 ## [2.10.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.9.0..2.10.0)
 
 ### Added

--- a/src/homematicip/async_home.py
+++ b/src/homematicip/async_home.py
@@ -256,6 +256,8 @@ class AsyncHome(HomeMaticIPObject):
 
         - ``HmipAuthenticationError`` is re-raised immediately so the caller
           can trigger reauth.
+        - ``HomeNotInitializedError`` is re-raised immediately because it
+          signals a programmer error (calling this before ``init``).
         - ``asyncio.CancelledError`` is re-raised to propagate cancellation.
         - All other exceptions, including ``HmipConnectionError`` subclasses
           and unforeseen errors, trigger a retry with exponential backoff
@@ -270,7 +272,7 @@ class AsyncHome(HomeMaticIPObject):
         while True:
             try:
                 return await self.get_current_state_async(clear_config=clear_config)
-            except HmipAuthenticationError:
+            except (HmipAuthenticationError, HomeNotInitializedError):
                 raise
             except asyncio.CancelledError:
                 raise

--- a/src/homematicip/async_home.py
+++ b/src/homematicip/async_home.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import warnings
 from collections.abc import Callable
@@ -241,6 +242,51 @@ class AsyncHome(HomeMaticIPObject):
         logger.debug("Run get_current_state_async")
         json_state = await self.download_configuration_async()
         return self.update_home(json_state, clear_config)
+
+    async def get_current_state_async_with_retry(
+        self,
+        clear_config: bool = False,
+        initial_delay: float = 8.0,
+        max_delay: float = 1500.0,
+    ):
+        """Refresh state with exponential backoff retry on transient errors.
+
+        Wraps :meth:`get_current_state_async` with a retry loop intended for
+        post-reconnect recovery in long-running clients (e.g. Home Assistant).
+
+        - ``HmipAuthenticationError`` is re-raised immediately so the caller
+          can trigger reauth.
+        - ``asyncio.CancelledError`` is re-raised to propagate cancellation.
+        - All other exceptions, including ``HmipConnectionError`` subclasses
+          and unforeseen errors, trigger a retry with exponential backoff
+          (``initial_delay`` doubling up to ``max_delay`` seconds).
+
+        Args:
+            clear_config: forwarded to :meth:`get_current_state_async`.
+            initial_delay: seconds to wait before the first retry.
+            max_delay: cap on the backoff delay between retries.
+        """
+        delay = initial_delay
+        while True:
+            try:
+                return await self.get_current_state_async(clear_config=clear_config)
+            except HmipAuthenticationError:
+                raise
+            except asyncio.CancelledError:
+                raise
+            except HmipConnectionError as err:
+                logger.warning(
+                    "get_current_state failed, retrying in %s seconds: %s",
+                    delay,
+                    err,
+                )
+            except Exception:
+                logger.exception(
+                    "Unexpected error in get_current_state, retrying in %s seconds",
+                    delay,
+                )
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, max_delay)
 
     def update_home(self, json_state, clear_config: bool = False):
         """parse a given json configuration into self.

--- a/src/homematicip/async_home.py
+++ b/src/homematicip/async_home.py
@@ -263,9 +263,16 @@ class AsyncHome(HomeMaticIPObject):
         Args:
             timeout: maximum total wait, in seconds.
             poll_interval: how often to check :meth:`websocket_is_connected`.
+                Must be > 0.
             warning_threshold: emit a "still waiting" warning once this many
                 seconds have elapsed without a connection.
+
+        Raises:
+            ValueError: if ``poll_interval`` is not positive.
         """
+        if poll_interval <= 0:
+            raise ValueError("poll_interval must be positive")
+
         elapsed = 0.0
         warning_logged = False
 
@@ -276,11 +283,12 @@ class AsyncHome(HomeMaticIPObject):
                     timeout,
                 )
                 return False
-            await asyncio.sleep(poll_interval)
-            elapsed += poll_interval
+            sleep_for = min(poll_interval, timeout - elapsed)
+            await asyncio.sleep(sleep_for)
+            elapsed += sleep_for
             if (
                 not warning_logged
-                and elapsed >= warning_threshold
+                and warning_threshold <= elapsed < timeout
                 and not self.websocket_is_connected()
             ):
                 warning_logged = True

--- a/src/homematicip/async_home.py
+++ b/src/homematicip/async_home.py
@@ -243,6 +243,86 @@ class AsyncHome(HomeMaticIPObject):
         json_state = await self.download_configuration_async()
         return self.update_home(json_state, clear_config)
 
+    async def wait_for_websocket_connection_async(
+        self,
+        timeout: float = 120.0,
+        poll_interval: float = 2.0,
+        warning_threshold: float = 60.0,
+    ) -> bool:
+        """Wait up to ``timeout`` seconds for the websocket to report connected.
+
+        Polls :meth:`websocket_is_connected` every ``poll_interval`` seconds.
+        If still not connected after ``warning_threshold`` seconds, emits a
+        single ``WARNING`` log line. Returns ``True`` once connected, or
+        ``False`` if ``timeout`` elapses first.
+
+        Designed for post-reconnect recovery in long-running clients
+        (e.g. Home Assistant). Callers typically proceed with a state
+        refresh even on timeout, since a REST call may still recover state.
+
+        Args:
+            timeout: maximum total wait, in seconds.
+            poll_interval: how often to check :meth:`websocket_is_connected`.
+            warning_threshold: emit a "still waiting" warning once this many
+                seconds have elapsed without a connection.
+        """
+        elapsed = 0.0
+        warning_logged = False
+
+        while not self.websocket_is_connected():
+            if elapsed >= timeout:
+                logger.warning(
+                    "Websocket did not reconnect within %s seconds",
+                    timeout,
+                )
+                return False
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+            if (
+                not warning_logged
+                and elapsed >= warning_threshold
+                and not self.websocket_is_connected()
+            ):
+                warning_logged = True
+                logger.warning(
+                    "Still waiting for websocket reconnect after %s seconds",
+                    elapsed,
+                )
+
+        return True
+
+    async def refresh_state_after_reconnect_async(
+        self,
+        clear_config: bool = False,
+        websocket_timeout: float = 120.0,
+        websocket_poll_interval: float = 2.0,
+        websocket_warning_threshold: float = 60.0,
+        retry_initial_delay: float = 8.0,
+        retry_max_delay: float = 1500.0,
+    ) -> None:
+        """Wait (best-effort) for websocket reconnect, then refresh state with retry.
+
+        Convenience wrapper combining :meth:`wait_for_websocket_connection_async`
+        and :meth:`get_current_state_async_with_retry`. The websocket wait is
+        best-effort: if it times out, the state refresh proceeds anyway, since
+        the REST call is independent and may still recover state.
+
+        Re-raises ``HmipAuthenticationError``, ``HomeNotInitializedError``, and
+        ``asyncio.CancelledError`` immediately. All other errors trigger retry.
+
+        Intended for post-reconnect recovery flows in long-running clients.
+        """
+        await self.wait_for_websocket_connection_async(
+            timeout=websocket_timeout,
+            poll_interval=websocket_poll_interval,
+            warning_threshold=websocket_warning_threshold,
+        )
+        await self.get_current_state_async_with_retry(
+            clear_config=clear_config,
+            initial_delay=retry_initial_delay,
+            max_delay=retry_max_delay,
+        )
+
     async def get_current_state_async_with_retry(
         self,
         clear_config: bool = False,

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -192,6 +192,17 @@ async def test_get_current_state_async_with_retry_raises_auth_error_immediately(
 
 
 @pytest.mark.asyncio
+async def test_get_current_state_async_with_retry_raises_home_not_initialized_immediately(fake_home: Home):
+    """HomeNotInitializedError signals a programmer error and must not retry."""
+    with patch.object(fake_home, "get_current_state_async", new=AsyncMock(side_effect=HomeNotInitializedError())) as mocked, \
+         patch("asyncio.sleep", new=AsyncMock()) as sleep_mock, \
+         pytest.raises(HomeNotInitializedError):
+        await fake_home.get_current_state_async_with_retry()
+    assert mocked.await_count == 1
+    sleep_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_get_current_state_async_with_retry_propagates_cancellation(fake_home: Home):
     """asyncio.CancelledError is re-raised, not swallowed."""
     import asyncio

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -275,6 +275,50 @@ async def test_wait_for_websocket_connection_returns_false_on_timeout(fake_home:
 
 
 @pytest.mark.asyncio
+async def test_wait_for_websocket_connection_respects_uneven_timeout(fake_home: Home):
+    """Total wait does not exceed timeout when timeout is not a multiple of poll_interval."""
+    sleep_args = []
+    async def fake_sleep(d):
+        sleep_args.append(d)
+    with patch.object(fake_home, "websocket_is_connected", return_value=False), \
+         patch("asyncio.sleep", new=fake_sleep):
+        await fake_home.wait_for_websocket_connection_async(
+            timeout=5, poll_interval=2, warning_threshold=100
+        )
+    # 2 + 2 + 1 = 5, not 6
+    assert sleep_args == [2, 2, 1]
+    assert sum(sleep_args) == pytest.approx(5.0)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_websocket_connection_no_double_warning_when_threshold_equals_timeout(
+    fake_home: Home, caplog
+):
+    """warning_threshold == timeout: the timeout warning fires, the threshold warning does not."""
+    with patch.object(fake_home, "websocket_is_connected", return_value=False), \
+         patch("asyncio.sleep", new=AsyncMock()), \
+         caplog.at_level("WARNING"):
+        await fake_home.wait_for_websocket_connection_async(
+            timeout=4, poll_interval=2, warning_threshold=4
+        )
+    still_waiting = [r for r in caplog.records if "Still waiting" in r.message]
+    timeout_logged = [r for r in caplog.records if "did not reconnect" in r.message]
+    assert len(still_waiting) == 0
+    assert len(timeout_logged) == 1
+
+
+@pytest.mark.asyncio
+async def test_wait_for_websocket_connection_rejects_non_positive_poll_interval(fake_home: Home):
+    """poll_interval <= 0 is rejected up-front to avoid a hung coroutine."""
+    with patch.object(fake_home, "websocket_is_connected", return_value=False), \
+         pytest.raises(ValueError):
+        await fake_home.wait_for_websocket_connection_async(poll_interval=0)
+    with patch.object(fake_home, "websocket_is_connected", return_value=False), \
+         pytest.raises(ValueError):
+        await fake_home.wait_for_websocket_connection_async(poll_interval=-1)
+
+
+@pytest.mark.asyncio
 async def test_wait_for_websocket_connection_logs_warning_after_threshold(fake_home: Home, caplog):
     """Emits a single warning once warning_threshold has elapsed."""
     with patch.object(fake_home, "websocket_is_connected", return_value=False), \

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -239,6 +239,85 @@ async def test_get_current_state_async_with_retry_caps_delay(fake_home: Home):
     assert sleep_args == [2, 4, 5]
 
 
+@pytest.mark.asyncio
+async def test_wait_for_websocket_connection_returns_true_immediately_when_connected(fake_home: Home):
+    """Returns True without sleeping when websocket is already connected."""
+    with patch.object(fake_home, "websocket_is_connected", return_value=True), \
+         patch("asyncio.sleep", new=AsyncMock()) as sleep_mock:
+        result = await fake_home.wait_for_websocket_connection_async()
+    assert result is True
+    sleep_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_websocket_connection_returns_true_when_connection_arrives(fake_home: Home):
+    """Polls and returns True when connection arrives mid-wait."""
+    states = [False, False, True]
+    with patch.object(fake_home, "websocket_is_connected", side_effect=states), \
+         patch("asyncio.sleep", new=AsyncMock()) as sleep_mock:
+        result = await fake_home.wait_for_websocket_connection_async(
+            timeout=10, poll_interval=2, warning_threshold=100
+        )
+    assert result is True
+    # Two sleeps before the True state arrives
+    assert sleep_mock.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_wait_for_websocket_connection_returns_false_on_timeout(fake_home: Home):
+    """Returns False after timeout when never connected."""
+    with patch.object(fake_home, "websocket_is_connected", return_value=False), \
+         patch("asyncio.sleep", new=AsyncMock()):
+        result = await fake_home.wait_for_websocket_connection_async(
+            timeout=4, poll_interval=2, warning_threshold=100
+        )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_wait_for_websocket_connection_logs_warning_after_threshold(fake_home: Home, caplog):
+    """Emits a single warning once warning_threshold has elapsed."""
+    with patch.object(fake_home, "websocket_is_connected", return_value=False), \
+         patch("asyncio.sleep", new=AsyncMock()), \
+         caplog.at_level("WARNING"):
+        await fake_home.wait_for_websocket_connection_async(
+            timeout=10, poll_interval=2, warning_threshold=4
+        )
+    still_waiting = [r for r in caplog.records if "Still waiting" in r.message]
+    timeout = [r for r in caplog.records if "did not reconnect" in r.message]
+    assert len(still_waiting) == 1
+    assert len(timeout) == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_state_after_reconnect_calls_wait_then_retry(fake_home: Home):
+    """Composition: waits for websocket, then runs the retry refresh."""
+    call_order = []
+    async def fake_wait(**_kwargs):
+        call_order.append("wait")
+        return True
+    async def fake_retry(**_kwargs):
+        call_order.append("retry")
+    with patch.object(fake_home, "wait_for_websocket_connection_async", new=fake_wait), \
+         patch.object(fake_home, "get_current_state_async_with_retry", new=fake_retry):
+        await fake_home.refresh_state_after_reconnect_async()
+    assert call_order == ["wait", "retry"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_state_after_reconnect_proceeds_on_websocket_timeout(fake_home: Home):
+    """Even when wait returns False (timeout), retry still runs."""
+    retry_called = []
+    async def fake_wait(**_kwargs):
+        return False
+    async def fake_retry(**_kwargs):
+        retry_called.append(True)
+    with patch.object(fake_home, "wait_for_websocket_connection_async", new=fake_wait), \
+         patch.object(fake_home, "get_current_state_async_with_retry", new=fake_retry):
+        await fake_home.refresh_state_after_reconnect_async()
+    assert retry_called == [True]
+
+
 def test_home_update_home(fake_home: Home):
     configuration = fake_home.download_configuration()
 

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -159,6 +159,75 @@ async def test_home_download_configuration_auth_error(fake_home: Home):
         await fake_home.download_configuration_async()
 
 
+@pytest.mark.asyncio
+async def test_get_current_state_async_with_retry_succeeds_first_try(fake_home: Home):
+    """Returns immediately when get_current_state_async succeeds."""
+    with patch.object(fake_home, "get_current_state_async", new=AsyncMock(return_value=None)) as mocked, \
+         patch("asyncio.sleep", new=AsyncMock()) as sleep_mock:
+        await fake_home.get_current_state_async_with_retry()
+    assert mocked.await_count == 1
+    sleep_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_current_state_async_with_retry_retries_on_connection_error(fake_home: Home):
+    """Retries on HmipConnectionError, then succeeds."""
+    side_effects = [HmipConnectionError("boom"), HmipConnectionError("again"), None]
+    with patch.object(fake_home, "get_current_state_async", new=AsyncMock(side_effect=side_effects)) as mocked, \
+         patch("asyncio.sleep", new=AsyncMock()) as sleep_mock:
+        await fake_home.get_current_state_async_with_retry(initial_delay=1, max_delay=10)
+    assert mocked.await_count == 3
+    assert sleep_mock.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_get_current_state_async_with_retry_raises_auth_error_immediately(fake_home: Home):
+    """HmipAuthenticationError propagates without retry."""
+    with patch.object(fake_home, "get_current_state_async", new=AsyncMock(side_effect=HmipAuthenticationError("nope"))) as mocked, \
+         patch("asyncio.sleep", new=AsyncMock()) as sleep_mock, \
+         pytest.raises(HmipAuthenticationError):
+        await fake_home.get_current_state_async_with_retry()
+    assert mocked.await_count == 1
+    sleep_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_current_state_async_with_retry_propagates_cancellation(fake_home: Home):
+    """asyncio.CancelledError is re-raised, not swallowed."""
+    import asyncio
+    with patch.object(fake_home, "get_current_state_async", new=AsyncMock(side_effect=asyncio.CancelledError())) as mocked, \
+         patch("asyncio.sleep", new=AsyncMock()), \
+         pytest.raises(asyncio.CancelledError):
+        await fake_home.get_current_state_async_with_retry()
+    assert mocked.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_current_state_async_with_retry_retries_on_unexpected_exception(fake_home: Home):
+    """Unforeseen exceptions also trigger retry (covers cases like the
+    NoneType error that motivated keeping a catch-all in the recovery loop)."""
+    side_effects = [TypeError("NoneType has no attribute"), None]
+    with patch.object(fake_home, "get_current_state_async", new=AsyncMock(side_effect=side_effects)) as mocked, \
+         patch("asyncio.sleep", new=AsyncMock()) as sleep_mock:
+        await fake_home.get_current_state_async_with_retry(initial_delay=1)
+    assert mocked.await_count == 2
+    assert sleep_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_current_state_async_with_retry_caps_delay(fake_home: Home):
+    """Backoff doubles but does not exceed max_delay."""
+    side_effects = [HmipConnectionError("e1"), HmipConnectionError("e2"), HmipConnectionError("e3"), None]
+    sleep_args = []
+    async def fake_sleep(d):
+        sleep_args.append(d)
+    with patch.object(fake_home, "get_current_state_async", new=AsyncMock(side_effect=side_effects)), \
+         patch("asyncio.sleep", new=fake_sleep):
+        await fake_home.get_current_state_async_with_retry(initial_delay=2, max_delay=5)
+    # 2, 4, then capped at 5
+    assert sleep_args == [2, 4, 5]
+
+
 def test_home_update_home(fake_home: Home):
     configuration = fake_home.download_configuration()
 


### PR DESCRIPTION
## Summary

Adds three methods on `AsyncHome` so long-running clients (e.g. Home Assistant) can move the entire post-reconnect recovery flow into the library:

- `wait_for_websocket_connection_async(timeout, poll_interval, warning_threshold)`: bounded best-effort wait for `websocket_is_connected()`, with a configurable warning log when the wait gets long. Returns `True` on success, `False` on timeout.
- `get_current_state_async_with_retry(initial_delay, max_delay)`: exponential-backoff retry around `get_current_state_async`. Re-raises `HmipAuthenticationError`, `HomeNotInitializedError`, and `asyncio.CancelledError` immediately; retries on `HmipConnectionError` and unforeseen exceptions.
- `refresh_state_after_reconnect_async(...)`: convenience wrapper that runs the wait, then the retrying refresh.

## Why

Unblocks home-assistant/core#169526. @edenhaus reviewed the HA-side reconnect logic and pointed out:
1. The bare `except Exception:` in the recovery loop violates HA Core's lint rules outside config flow.
2. All the timing and recovery logic is API-specific knowledge and belongs in the library, where catching broad exceptions is unproblematic.

Both points are addressed here. With these helpers, the HA integration's `_try_get_state` collapses into a single `await self.home.refresh_state_after_reconnect_async()` and the bare except disappears.

The catch-all in `get_current_state_async_with_retry` is intentional and preserves the protection that motivated the original HA-side code: a `NoneType` parsing error in core#160048 would have been silently swallowed by a narrow catch and stuck the integration permanently.

## Tests

13 new tests in `tests/test_home.py` covering retry semantics (success first try, retry on connection error, immediate auth/not-initialized/cancellation re-raise, retry on unexpected exception, backoff cap), websocket-wait semantics (already-connected, becomes-connected, timeout, warning threshold), and composition (wait+retry order, proceeds on wait timeout).

`pytest tests/` 300 passed, `ruff check` clean.