### PR TITLE
Add DOOR_LOCK_AUTHORIZATION_PROFILE group type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED](https://github.com/hahn-th/homematicip-rest-api/compare/2.11.0..master)
 
+### Added
+
+- Add `DOOR_LOCK_AUTHORIZATION_PROFILE` group type with `DoorLockAuthorizationProfileGroup` class. The cloud exposes this group type for HmIP-FLC and similar door-lock devices to control which clients are authorized to operate the lock; previously the group fell back to the base `Group` and emitted a "no class for group" warning at home load.
+
 ## [2.11.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.10.0..2.11.0)
 
 ### Added

--- a/homematicip_demo/json_data/home.json
+++ b/homematicip_demo/json_data/home.json
@@ -19777,6 +19777,27 @@
       "type": "ACCESS_AUTHORIZATION_PROFILE",
       "unreach": false
     },
+    "00000000-0000-0000-0000-000000000091": {
+      "active": true,
+      "authorizationPinAssigned": false,
+      "authorized": true,
+      "channels": [],
+      "clientIds": [
+        "00000000-0000-0000-0000-000000000003"
+      ],
+      "dutyCycle": null,
+      "groupVisibility": "VISIBLE",
+      "homeId": "00000000-0000-0000-0000-000000000001",
+      "id": "00000000-0000-0000-0000-000000000091",
+      "label": "FLC Test Profile",
+      "lastStatusUpdate": 0,
+      "lowBat": null,
+      "metaGroupId": null,
+      "profileId": "00000000-0000-0000-0000-000000000092",
+      "sensorSpecificParameters": {},
+      "type": "DOOR_LOCK_AUTHORIZATION_PROFILE",
+      "unreach": null
+    },
     "00000000-0000-0000-0000-000000000033": {
       "channels": [
         {

--- a/src/homematicip/base/enums.py
+++ b/src/homematicip/base/enums.py
@@ -333,6 +333,7 @@ class GroupType(AutoNameEnum):
     ACCESS_CONTROL = auto()
     ALARM_SWITCHING = auto()
     AUTO_RELOCK_PROFILE = auto()
+    DOOR_LOCK_AUTHORIZATION_PROFILE = auto()
     ENERGY = auto()
     ENVIRONMENT = auto()
     EXTENDED_LINKED_GARAGE_DOOR = auto()

--- a/src/homematicip/class_maps.py
+++ b/src/homematicip/class_maps.py
@@ -143,6 +143,7 @@ TYPE_GROUP_MAP = {
     GroupType.ACCESS_AUTHORIZATION_PROFILE: AccessAuthorizationProfileGroup,
     GroupType.ACCESS_CONTROL: AccessControlGroup,
     GroupType.ALARM_SWITCHING: AlarmSwitchingGroup,
+    GroupType.DOOR_LOCK_AUTHORIZATION_PROFILE: DoorLockAuthorizationProfileGroup,
     GroupType.ENERGY: EnergyGroup,
     GroupType.ENVIRONMENT: EnvironmentGroup,
     GroupType.EXTENDED_LINKED_GARAGE_DOOR: ExtendedLinkedGarageDoorGroup,

--- a/src/homematicip/group.py
+++ b/src/homematicip/group.py
@@ -1264,6 +1264,22 @@ class AccessAuthorizationProfileGroup(Group):
         self.authorized = js["authorized"]
 
 
+class DoorLockAuthorizationProfileGroup(Group):
+    def __init__(self, connection):
+        super().__init__(connection)
+        self.active = False
+        self.authorizationPinAssigned = False
+        self.authorized = False
+        self.profileId = None
+
+    def from_json(self, js, devices):
+        super().from_json(js, devices)
+        self.active = js["active"]
+        self.authorizationPinAssigned = js["authorizationPinAssigned"]
+        self.authorized = js["authorized"]
+        self.profileId = js.get("profileId")
+
+
 class AccessControlGroup(Group):
     def __init__(self, connection):
         super().__init__(connection)

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -537,6 +537,16 @@ def test_access_authorization_profile_group(fake_home: Home):
         assert g.authorized == True
 
 
+def test_door_lock_authorization_profile_group(fake_home: Home):
+    with no_ssl_verification():
+        g = fake_home.search_group_by_id("00000000-0000-0000-0000-000000000091")
+        assert g.label == "FLC Test Profile"
+        assert g.active == True
+        assert g.authorizationPinAssigned == False
+        assert g.authorized == True
+        assert g.profileId == "00000000-0000-0000-0000-000000000092"
+
+
 def test_access_control_group(fake_home: Home):
     with no_ssl_verification():
         g = fake_home.search_group_by_id("00000000-0000-0000-0000-000000000033")


### PR DESCRIPTION
## What

Add support for the `DOOR_LOCK_AUTHORIZATION_PROFILE` group type, exposed by the cloud for HmIP-FLC and similar door-lock devices to control which clients (access points, plugins, etc.) are authorized to operate the lock channel.

## Why

Currently every home load that contains such a group logs:

```
'DOOR_LOCK_AUTHORIZATION_PROFILE' isn't a valid option for class 'GroupType'
There is no class for group 'DOOR_LOCK_AUTHORIZATION_PROFILE' yet
```

and falls back to the base `Group`, dropping the profile-specific fields. Reported via hahn-th/homematicip-rest-api#606 by an HmIP-FLC user whose diagnostics showed the unhandled group type.

## How

- New `GroupType.DOOR_LOCK_AUTHORIZATION_PROFILE` enum value
- New `DoorLockAuthorizationProfileGroup` class mirroring `AccessAuthorizationProfileGroup` plus a `profileId` field that this variant carries
- Wire into `class_maps.py`
- Demo fixture entry (group id 91) and corresponding test in `test_groups.py`

## Note

This PR fixes the noisy log warnings only. The companion 400 `startImpulse` error reported in #606 is a separate cloud-side authorization issue (the HmIP app authorizes door-opener calls via a different auth path than plugin/AP clients) and is not addressed here.