### PR TITLE
Add pull_latch command for door opener via access authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED](https://github.com/hahn-th/homematicip-rest-api/compare/2.11.0..master)
 
+### Added
+
+- Add `pull_latch` / `async_pull_latch` on `AccessAuthorizationChannel` (and the underlying `pull_latch_async` command) to trigger a door opener via the cloud's `device/control/pullLatch` endpoint. This is the correct endpoint for `ACCESS_AUTHORIZATION_CHANNEL` channels with role `DOOR_OPENER_ACTUATOR` (e.g. on HmIP-FLC, HmIP-DLD): the cloud routes the impulse through the access-authorization profile, so calling `startImpulse` directly on the underlying `DOOR_SWITCH_CHANNEL` fails with `CLIENT_ACCESS_DENIED` for non-admin clients. Optional `pin` parameter is forwarded as `authorizationPin` for profiles that require a PIN.
+
 ## [2.11.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.10.0..2.11.0)
 
 ### Added

--- a/src/homematicip/base/functionalChannels.py
+++ b/src/homematicip/base/functionalChannels.py
@@ -1502,6 +1502,19 @@ class AccessAuthorizationChannel(FunctionalChannel):
         super().from_json(js, groups)
         self.authorized = js["authorized"]
 
+    def pull_latch(self, pin: str | None = None):
+        """Trigger the latch via this access-authorization channel.
+
+        Only meaningful for channels with role ``DOOR_OPENER_ACTUATOR``.
+        See :func:`homematicip.commands.functional_channel_commands.pull_latch_async`.
+        """
+        return self._run_non_async(lambda: self.async_pull_latch(pin))
+
+    async def async_pull_latch(self, pin: str | None = None):
+        return await functional_channel_commands.pull_latch_async(
+            self._connection, self.device.id, self.index, pin
+        )
+
 
 class HeatingThermostatChannel(FunctionalChannel):
     """this is the representative of the HEATING_THERMOSTAT_CHANNEL channel"""

--- a/src/homematicip/commands/functional_channel_commands.py
+++ b/src/homematicip/commands/functional_channel_commands.py
@@ -596,6 +596,36 @@ async def start_impulse_async(rest_connection: RestConnection, device_id: str, c
     return await rest_connection.async_post("device/control/startImpulse", data)
 
 
+async def pull_latch_async(rest_connection: RestConnection, device_id: str, channel_index: int,
+                           pin: str | None = None):
+    """
+    Trigger the latch of a door opening device by activating the switching output of the
+    target device channel for its configured impulse duration.
+
+    Both the requesting client and the target device channel must belong to the same
+    access authorization. Used for ``ACCESS_AUTHORIZATION_CHANNEL`` channels with role
+    ``DOOR_OPENER_ACTUATOR`` (e.g. on HmIP-FLC, HmIP-DLD).
+
+    :param rest_connection: The REST connection instance.
+    :type rest_connection: RestConnection
+    :param device_id: The device ID.
+    :type device_id: str
+    :param channel_index: The channel index of the access-authorization channel.
+    :type channel_index: int
+    :param pin: The authorization PIN (optional, only required if a PIN is configured
+        on the access authorization profile).
+    :type pin: str or None
+    :return: The response from the cloud.
+    :rtype: dict
+    """
+    data = {
+        "channelIndex": channel_index,
+        "deviceId": device_id,
+        "authorizationPin": pin,
+    }
+    return await rest_connection.async_post("device/control/pullLatch", data)
+
+
 async def set_acceleration_sensor_mode_async(rest_connection: RestConnection, device_id: str, channel_index: int,
                                              mode: str):
     """

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -118,6 +118,17 @@ def _full_flush_lock_controller_json():
                 "label": "",
                 "supportedOptionalFeatures": {},
             },
+            "9": {
+                "authorized": True,
+                "channelRole": "DOOR_OPENER_ACTUATOR",
+                "deviceId": "3014F7110000000000000026",
+                "functionalChannelType": "ACCESS_AUTHORIZATION_CHANNEL",
+                "groupIndex": 4,
+                "groups": [],
+                "index": 9,
+                "label": "",
+                "supportedOptionalFeatures": {},
+            },
         },
         "homeId": "00000000-0000-0000-0000-000000000001",
         "id": "3014F7110000000000000026",
@@ -203,6 +214,46 @@ def test_full_flush_lock_controller_channel_first_support():
         d.send_start_impulse()
 
     patched.assert_awaited_once_with(d._connection, d.id, 4)
+
+
+def test_full_flush_lock_controller_pull_latch():
+    d = _build_full_flush_lock_controller()
+
+    door_opener_auth_channel = next(
+        ch
+        for ch in d.functionalChannels
+        if ch.functionalChannelType == FunctionalChannelType.ACCESS_AUTHORIZATION_CHANNEL
+        and ch.channelRole == "DOOR_OPENER_ACTUATOR"
+    )
+    assert isinstance(door_opener_auth_channel, AccessAuthorizationChannel)
+    assert door_opener_auth_channel.index == 9
+
+    with patch(
+        "homematicip.commands.functional_channel_commands.pull_latch_async",
+        new_callable=AsyncMock,
+    ) as patched:
+        door_opener_auth_channel.pull_latch()
+
+    patched.assert_awaited_once_with(d._connection, d.id, 9, None)
+
+
+def test_full_flush_lock_controller_pull_latch_with_pin():
+    d = _build_full_flush_lock_controller()
+
+    door_opener_auth_channel = next(
+        ch
+        for ch in d.functionalChannels
+        if ch.functionalChannelType == FunctionalChannelType.ACCESS_AUTHORIZATION_CHANNEL
+        and ch.channelRole == "DOOR_OPENER_ACTUATOR"
+    )
+
+    with patch(
+        "homematicip.commands.functional_channel_commands.pull_latch_async",
+        new_callable=AsyncMock,
+    ) as patched:
+        door_opener_auth_channel.pull_latch("1234")
+
+    patched.assert_awaited_once_with(d._connection, d.id, 9, "1234")
 
 
 def test_room_control_device(fake_home: Home):


### PR DESCRIPTION
## What

Adds `pull_latch` / `async_pull_latch` on `AccessAuthorizationChannel` plus the underlying `pull_latch_async` command. The new command wraps the cloud's `device/control/pullLatch` endpoint described in the connect-api specification (section 6.8.1.2).

This is the correct path for `ACCESS_AUTHORIZATION_CHANNEL` channels with role `DOOR_OPENER_ACTUATOR` on devices such as HmIP-FLC and HmIP-DLD.

## Why

Third-party clients listed in an `ACCESS_AUTHORIZATION_PROFILE` cannot trigger the door opener via `send_start_impulse()` on the underlying `DOOR_SWITCH_CHANNEL`: the cloud rejects `startImpulse` on the physical switch index with `CLIENT_ACCESS_DENIED`, because the access profile lists the access-authorization channel index (e.g. ch9 on HmIP-FLC), not the physical switch index (ch4). `pullLatch` targets the access-authorization channel so the cloud-side authorization check matches.

This was reported against HmIP-FLC by a Home Assistant user via #606. Diagnostic dump confirmed the profile contains the HA OAuth client and a `DOOR_OPENER_ACTUATOR` access-authorization channel, but the lib was sending the wrong endpoint at the wrong channel.

Reference (connect-api-documentation-1.0.1.html, 6.8.1.2):
> Triggers the latch of a door opening device by activating the switching output of the target device channel for the configured duration.
> Notes: Both the requesting client and the target device channel must belong to the same access authorization.

## Changes

- `commands/functional_channel_commands.py`: new `pull_latch_async(rest_connection, device_id, channel_index, pin=None)`; sends `channelIndex`, `deviceId`, `authorizationPin` to `device/control/pullLatch`.
- `base/functionalChannels.py`: `AccessAuthorizationChannel` gains `pull_latch(pin=None)` and `async_pull_latch(pin=None)`.
- `tests/test_devices.py`: extends the HmIP-FLC fixture with a `DOOR_OPENER_ACTUATOR` access-authorization channel (index 9) and adds two tests covering dispatch with and without PIN.
- `CHANGELOG.md`: entry under `[UNRELEASED]`.

## Tests

```
$ pytest tests/ --asyncio-mode=auto
305 passed, 527 warnings in 17.40s

$ ruff check src/ tests/
All checks passed!
```

Diff: +98 / -0.

## Follow-up

A companion HA Core PR will switch the FLC button entity to call `pull_latch()` on the `ACCESS_AUTHORIZATION_CHANNEL` rather than `send_start_impulse()` on the physical `DOOR_SWITCH_CHANNEL`, plus wire it through for HmIP-DLD.