### PR TITLE
Add KEY_PRESS_* channel event types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED](https://github.com/hahn-th/homematicip-rest-api/compare/2.11.0..master)
 
+### Added
+
+- Extend `ChannelEventTypes` enum with the four channel event type strings the HomematicIP cloud emits for `SINGLE_KEY_CHANNEL` button presses (HmIP-WRC2, HmIP-WRC6, HmIP-WRC6-230, ...):
+  - `KEY_PRESS_SHORT`: fires once on a short press
+  - `KEY_PRESS_LONG_START`: fires once at the beginning of a long press
+  - `KEY_PRESS_LONG`: fires repeatedly (~every 250 ms) while the button is held
+  - `KEY_PRESS_LONG_STOP`: fires once when the button is released after a long press
+
 ## [2.11.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.10.0..2.11.0)
 
 ### Added

--- a/src/homematicip/base/enums.py
+++ b/src/homematicip/base/enums.py
@@ -546,6 +546,10 @@ class FunctionalChannelType(AutoNameEnum):
 
 class ChannelEventTypes(AutoNameEnum):
     DOOR_BELL_SENSOR_EVENT = auto()
+    KEY_PRESS_SHORT = auto()
+    KEY_PRESS_LONG = auto()
+    KEY_PRESS_LONG_START = auto()
+    KEY_PRESS_LONG_STOP = auto()
 
 
 class HeatingLoadType(AutoNameEnum):

--- a/tests/test_functional_channels.py
+++ b/tests/test_functional_channels.py
@@ -1,11 +1,12 @@
 from unittest.mock import AsyncMock, Mock
 
+import pytest
 from homematicip_demo.helper import (
     no_ssl_verification,
 )
 
 from homematicip.base.channel_event import ChannelEvent
-from homematicip.base.enums import FunctionalChannelType
+from homematicip.base.enums import ChannelEventTypes, FunctionalChannelType
 from homematicip.base.functionalChannels import *
 from homematicip.device import *
 from homematicip.home import Home
@@ -560,6 +561,40 @@ def test_door_bell_channel_event(fake_home: Home):
         ch.fire_channel_event(channel_event)
 
         handler.assert_called_once_with(channel_event)
+
+
+@pytest.mark.parametrize(
+    "channel_event_type",
+    [
+        "KEY_PRESS_SHORT",
+        "KEY_PRESS_LONG",
+        "KEY_PRESS_LONG_START",
+        "KEY_PRESS_LONG_STOP",
+    ],
+)
+def test_key_press_channel_event(fake_home: Home, channel_event_type: str):
+    with no_ssl_verification():
+        handler = Mock()
+        ch = fake_home.search_channel("3014F711000000000WRC6230", 1)
+        channel_event = ChannelEvent()
+        channel_event.from_json(
+            {
+                "pushEventType": "DEVICE_CHANNEL_EVENT",
+                "deviceId": "3014F711000000000WRC6230",
+                "channelIndex": 1,
+                "channelEventType": channel_event_type,
+                "functionalChannelIndex": 1,
+            }
+        )
+        ch.add_on_channel_event_handler(handler)
+
+        ch.fire_channel_event(channel_event)
+
+        handler.assert_called_once_with(channel_event)
+        assert (
+            ChannelEventTypes.from_str(channel_event_type)
+            == ChannelEventTypes(channel_event_type)
+        )
 
 
 def test_channel_role_read(fake_home: Home):


### PR DESCRIPTION
## Description

Extends the `ChannelEventTypes` enum with the four channel event type strings the
HomematicIP cloud emits for `SINGLE_KEY_CHANNEL` button presses (HmIP-WRC2, HmIP-WRC6,
HmIP-WRC6-230, ...):

- `KEY_PRESS_SHORT`: fires once on a short press
- `KEY_PRESS_LONG_START`: fires once at the beginning of a long press
- `KEY_PRESS_LONG`: fires repeatedly (~every 250 ms) while the button is held
- `KEY_PRESS_LONG_STOP`: fires once when the button is released after a long press

Empirically confirmed via debug logs from a HmIP-WRC6-230 (#648).

## Why

Currently these events arrive as raw strings without enum classification.
Adding them lets downstream consumers (e.g. the Home Assistant `homematicip_cloud`
integration) filter on `ChannelEventTypes.KEY_PRESS_SHORT` etc. instead of
comparing raw strings. This is the basis for a planned HA Core change exposing
per-button `event` entities for SINGLE_KEY_CHANNEL channels, following the
existing doorbell pattern.

## Changes

- `src/homematicip/base/enums.py`: four new enum values added to `ChannelEventTypes`
- `tests/test_functional_channels.py`: parametrized `test_key_press_channel_event` covering all four event types on the existing HmIP-WRC6-230 fixture
- `CHANGELOG.md`: `[UNRELEASED]` entry

## Tests

```
$ pytest tests/test_functional_channels.py -v -k channel_event
tests/test_functional_channels.py::test_door_bell_channel_event PASSED
tests/test_functional_channels.py::test_key_press_channel_event[KEY_PRESS_SHORT] PASSED
tests/test_functional_channels.py::test_key_press_channel_event[KEY_PRESS_LONG] PASSED
tests/test_functional_channels.py::test_key_press_channel_event[KEY_PRESS_LONG_START] PASSED
tests/test_functional_channels.py::test_key_press_channel_event[KEY_PRESS_LONG_STOP] PASSED
```

Full test suite: 307 passed. `ruff check src/ tests/` clean.