### PR TITLE
Enable additional ruff rules and fix violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED](https://github.com/hahn-th/homematicip-rest-api/compare/2.11.0..master)
 
+### Changed
+
+- Enable additional ruff rule sets to catch common bugs and tighten code quality:
+  - `ASYNC` (async correctness, e.g. `time.sleep` in async functions, `open()` blocking calls)
+  - `A` (Python builtin shadowing, e.g. `id`, `type`, `dict` as variable/argument names)
+  - `C4`, `ISC`, `TCH`, `TID` (already clean, added for enforcement going forward)
+  - `PERF` (manual list-append loops → comprehensions)
+  - `PT` (pytest style)
+  - `RSE` (unnecessary parens on `raise`)
+- Fix all violations exposed by the new rules (~22 changes). Notable: `time.sleep` in async auth flow replaced with `await asyncio.sleep`, internal builtin shadowing renamed (`id` → `gid`/`device_id`, `dict` → `data`, `type` → `enum_type` on the internal `set_attr_from_dict` helper). One public-API parameter name (`anonymizeConfig(format=...)`) is preserved with `# noqa` for backwards compatibility.
+
 ## [2.11.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.10.0..2.11.0)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,20 +53,30 @@ select = [
     "PIE",  # misc lints
     "G",    # logging-format (no f-strings in log messages, use .exception not .error+exc_info)
     "LOG",  # logging best practices
+    "A",    # builtin shadowing
+    "ASYNC", # async correctness
+    "C4",   # comprehensions
+    "ISC",  # implicit string concatenation
+    "PERF", # performance anti-patterns
+    "PT",   # pytest style
+    "RSE",  # raise style
+    "TCH",  # type-checking imports
+    "TID",  # tidy imports
     "RUF010",  # use !s/!r conversion flags
     "RUF012",  # mutable class attributes need ClassVar
     "RUF013",  # explicit Optional (no `x: int = None`)
 ]
 ignore = [
-    "F403",   # star imports (to be addressed separately)
-    "F405",   # names from star imports (consequence of F403)
-    "F811",   # redefinition of unused name (false positives from star imports)
-    "UP042",  # str(Enum) → StrEnum — behavioral differences, not a safe migration
-    "RET502", # implicit return None — style preference, can hurt readability
-    "RET503", # missing explicit return — same
-    "RET504", # unnecessary assignment before return — same
-    "SIM102", # collapsible if — nested ifs are sometimes clearer
-    "SIM112", # capitalized env vars — os.environ uses lowercase intentionally here
+    "F403",     # star imports (to be addressed separately)
+    "F405",     # names from star imports (consequence of F403)
+    "F811",     # redefinition of unused name (false positives from star imports)
+    "UP042",    # str(Enum) → StrEnum — behavioral differences, not a safe migration
+    "RET502",   # implicit return None — style preference, can hurt readability
+    "RET503",   # missing explicit return — same
+    "RET504",   # unnecessary assignment before return — same
+    "SIM102",   # collapsible if — nested ifs are sometimes clearer
+    "SIM112",   # capitalized env vars — os.environ uses lowercase intentionally here
+    "ASYNC109", # async function with timeout parameter — would break public API (wait_for_websocket_connection_async)
 ]
 
 [tool.pytest.ini_options]

--- a/src/homematicip/async_home.py
+++ b/src/homematicip/async_home.py
@@ -214,7 +214,7 @@ class AsyncHome(HomeMaticIPObject):
             Exception: if the download fails
         """
         if self._connection_context is None:
-            raise HomeNotInitializedError()
+            raise HomeNotInitializedError
 
         client_characteristics = ClientCharacteristicsBuilder.get(self._connection_context.accesspoint_id)
         result = await self._rest_call_async(

--- a/src/homematicip/base/functionalChannels.py
+++ b/src/homematicip/base/functionalChannels.py
@@ -53,9 +53,9 @@ class FunctionalChannel(HomeMaticIPObject):
             js["functionalChannelType"], js["functionalChannelType"]
         )
         self.groups = []
-        for id in js["groups"]:
+        for gid in js["groups"]:
             for g in groups:
-                if g.id == id:
+                if g.id == gid:
                     self.groups.append(g)
                     break
 

--- a/src/homematicip/base/helpers.py
+++ b/src/homematicip/base/helpers.py
@@ -14,11 +14,11 @@ def get_functional_channel(channel_type, js):
 
 
 def get_functional_channels(channel_type, js):
-    result = []
-    for channel in js["functionalChannels"].values():
-        if channel["functionalChannelType"] == channel_type:
-            result.append(channel)
-    return result
+    return [
+        channel
+        for channel in js["functionalChannels"].values()
+        if channel["functionalChannelType"] == channel_type
+    ]
 
 
 # from https://bugs.python.org/file43513/json_detect_encoding_3.patch
@@ -90,18 +90,18 @@ def handle_config(json_state: str, anonymize: bool) -> str:
     return c
 
 
-def anonymizeConfig(config, pattern, format, flags=re.IGNORECASE):
+def anonymizeConfig(config, pattern, format, flags=re.IGNORECASE):  # noqa: A002 — public API, preserved for backwards compatibility
     m = re.findall(pattern, config, flags=flags)
     if m is None:
         return config
-    map = {}
+    mapping = {}
     i = 0
     for s in m:
-        if s in map:
+        if s in mapping:
             continue
-        map[s] = format.format(i)
+        mapping[s] = format.format(i)
         i = i + 1
 
-    for k, v in map.items():
+    for k, v in mapping.items():
         config = config.replace(k, v)
     return config

--- a/src/homematicip/base/homematicip_object.py
+++ b/src/homematicip/base/homematicip_object.py
@@ -89,8 +89,8 @@ class HomeMaticIPObject:
     def set_attr_from_dict(
             self,
             attr: str,
-            dict,
-            type: AutoNameEnum = None,
+            data: dict,
+            enum_type: AutoNameEnum = None,
             dict_attr=None,
             addToStrOutput=True,
     ):
@@ -98,20 +98,20 @@ class HomeMaticIPObject:
 
         Args:
             attr(str): the attribute which value should be changed
-            dict(dict): the dictionary from which the value should be extracted
-            type(AutoNameEnum): this will call type.from_str(value), if a type gets provided
+            data(dict): the dictionary from which the value should be extracted
+            enum_type(AutoNameEnum): this will call enum_type.from_str(value), if a type gets provided
             dict_attr: the name of the attribute in the dict. Set this to None(default) to use attr
             addToStrOutput(str): should the attribute be returned via __str__()
         """
         if not dict_attr:
             dict_attr = attr
 
-        if dict_attr not in dict:
+        if dict_attr not in data:
             return
 
-        value = dict[dict_attr]
-        if type:
-            value = type.from_str(value)
+        value = data[dict_attr]
+        if enum_type:
+            value = enum_type.from_str(value)
 
         self.__dict__[attr] = value
         if addToStrOutput and attr not in self._dictAttributes:

--- a/src/homematicip/cli/hmip_cli.py
+++ b/src/homematicip/cli/hmip_cli.py
@@ -3,7 +3,6 @@ import json
 import logging
 import signal
 import sys
-import time
 import traceback
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from importlib.metadata import version
@@ -446,18 +445,18 @@ async def run(config: homematicip.HmipConfig, home: AsyncHome, logger: logging.L
         external = []
         error = False
         command_entered = True
-        for id in args.external_devices:
-            device = home.search_device_by_id(id)
+        for device_id in args.external_devices:
+            device = home.search_device_by_id(device_id)
             if device is None:
-                logger.error("Device %s is not registered on this Access Point", id)
+                logger.error("Device %s is not registered on this Access Point", device_id)
                 error = True
             else:
                 external.append(device)
 
-        for id in args.internal_devices:
-            device = home.search_device_by_id(id)
+        for device_id in args.internal_devices:
+            device = home.search_device_by_id(device_id)
             if device is None:
-                logger.error("Device %s is not registered on this Access Point", id)
+                logger.error("Device %s is not registered on this Access Point", device_id)
                 error = True
             else:
                 internal.append(device)
@@ -598,7 +597,7 @@ async def run(config: homematicip.HmipConfig, home: AsyncHome, logger: logging.L
             logger.info("Listening for events. Press Ctrl+c to stop.")
             print("Listening for events. Press Ctrl+c to stop.")
             await home.enable_events()
-            while True:
+            while True:  # noqa: ASYNC110 — CLI listener loop, exits via KeyboardInterrupt
                 await asyncio.sleep(1)
         except KeyboardInterrupt:
             await home.disable_events_async()
@@ -613,8 +612,8 @@ async def run(config: homematicip.HmipConfig, home: AsyncHome, logger: logging.L
         home.on_channel_event(lambda x: print(x))
         await home.enable_events(additional_message_handler=lambda x: print(x))
         try:
-            while True:
-                time.sleep(1)
+            while True:  # noqa: ASYNC110 — CLI listener loop, exits via KeyboardInterrupt
+                await asyncio.sleep(1)
         except KeyboardInterrupt:
             return
 
@@ -1131,7 +1130,7 @@ async def fake_download_configuration():
     """Use a json file as configuration source for the server."""
     global server_config
     if server_config:
-        with open(server_config) as file:
+        with open(server_config) as file:  # noqa: ASYNC230 — CLI tool, sync file read at startup is fine
             return json.load(file)
     return None
 

--- a/src/homematicip/cli/hmip_generate_auth_token.py
+++ b/src/homematicip/cli/hmip_generate_auth_token.py
@@ -13,11 +13,13 @@ async def run_auth(access_point: str | None = None, devicename: str | None = Non
     print(
         "If you are about to connect to a HomematicIP HCU1 you have to press the button on top of the device, before you continue.")
     print("From now, you have 5 Minutes to complete the registration process.")
-    input("Press Enter to continue...")
+    input("Press Enter to continue...")  # noqa: ASYNC250
 
     while True:
         access_point = (
-            input("Please enter the accesspoint id (SGTIN): ").replace("-", "").upper()
+            input("Please enter the accesspoint id (SGTIN): ")  # noqa: ASYNC250
+            .replace("-", "")
+            .upper()
         )
         if len(access_point) != 24:
             print("Invalid access_point id")
@@ -29,12 +31,12 @@ async def run_auth(access_point: str | None = None, devicename: str | None = Non
 
     auth = homematicip.auth.Auth(connection, context.client_auth_token, access_point)
 
-    devicename = input(
+    devicename = input(  # noqa: ASYNC250
         "Please enter the client/devicename (leave blank to use default):"
     )
 
     while True:
-        pin = input("Please enter the PIN (leave Blank if there is none): ")
+        pin = input("Please enter the PIN (leave Blank if there is none): ")  # noqa: ASYNC250
 
         if pin != "":
             auth.set_pin(pin)

--- a/src/homematicip/cli/hmip_generate_auth_token.py
+++ b/src/homematicip/cli/hmip_generate_auth_token.py
@@ -2,7 +2,6 @@
 import asyncio
 import configparser
 import json
-import time
 
 import homematicip
 import homematicip.auth
@@ -53,7 +52,7 @@ async def run_auth(access_point: str | None = None, devicename: str | None = Non
             print("PIN IS INVALID!")
         elif errorCode == "ASSIGNMENT_LOCKED":
             print("LOCKED ! Press button on HCU to unlock.")
-            time.sleep(5)
+            await asyncio.sleep(5)
         else:
             print(f"Error: {errorCode}\nExiting")
             return
@@ -62,7 +61,7 @@ async def run_auth(access_point: str | None = None, devicename: str | None = Non
     print("Please press the blue button on the access point")
     while not await auth.is_request_acknowledged():
         print("Please press the blue button on the access point")
-        time.sleep(2)
+        await asyncio.sleep(2)
 
     auth_token = await auth.request_auth_token()
     clientId = await auth.confirm_auth_token(auth_token)
@@ -81,7 +80,7 @@ async def run_auth(access_point: str | None = None, devicename: str | None = Non
     _config["AUTH"] = {"AuthToken": auth_token, "AccessPoint": access_point}
     _config.set("LOGGING", "Level", "30")
     _config.set("LOGGING", "FileName", "None")
-    with open("./config.ini", "w") as configfile:
+    with open("./config.ini", "w") as configfile:  # noqa: ASYNC230 — CLI tool, sync file write at finish is fine
         _config.write(configfile)
 
 

--- a/src/homematicip/device.py
+++ b/src/homematicip/device.py
@@ -718,7 +718,7 @@ class SmokeDetector(Device):
         super().from_json(js)
         c = get_functional_channel("SMOKE_DETECTOR_CHANNEL", js)
         if c:
-            self.set_attr_from_dict("smokeDetectorAlarmType", c, type=SmokeDetectorAlarmType)
+            self.set_attr_from_dict("smokeDetectorAlarmType", c, enum_type=SmokeDetectorAlarmType)
             self.set_attr_from_dict("chamberDegraded", c)
             self.set_attr_from_dict("dirtLevel", c)
             self.set_attr_from_dict("smokeDetectorGroupAssignment", c)

--- a/src/homematicip/functionalHomes.py
+++ b/src/homematicip/functionalHomes.py
@@ -24,9 +24,7 @@ class FunctionalHome(HomeMaticIPObject):
     def assignGroups(self, gids, groups: list[Group]):
         ret = []
         for gid in gids:
-            for g in groups:
-                if g.id == gid:
-                    ret.append(g)
+            ret.extend(g for g in groups if g.id == gid)
         return ret
 
 

--- a/src/homematicip/group.py
+++ b/src/homematicip/group.py
@@ -691,20 +691,17 @@ class HeatingCoolingProfile(HomeMaticIPObject):
     async def update_profile_async(self):
         days = {}
         for i in range(7):
-            periods = []
             day = self.profileDays[i]
-            for p in day.periods:
-                periods.append(
-                    {
-                        "endtime": p.endtime,
-                        "starttime": p.starttime,
-                        "value": p.value,
-                        "endtimeAsMinutesOfDay": self._time_to_totalminutes(p.endtime),
-                        "starttimeAsMinutesOfDay": self._time_to_totalminutes(
-                            p.starttime
-                        ),
-                    }
-                )
+            periods = [
+                {
+                    "endtime": p.endtime,
+                    "starttime": p.starttime,
+                    "value": p.value,
+                    "endtimeAsMinutesOfDay": self._time_to_totalminutes(p.endtime),
+                    "starttimeAsMinutesOfDay": self._time_to_totalminutes(p.starttime),
+                }
+                for p in day.periods
+            ]
 
             dayOfWeek = calendar.day_name[i].upper()
             days[dayOfWeek] = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,7 @@ async def session_stop_threads():
 
     stop_threads = True
     t.join()
-    while loop.is_running():  # pragma: no cover
+    while loop.is_running():  # pragma: no cover  # noqa: ASYNC110 — test fixture teardown polling background loop
         await asyncio.sleep(0.1)
     loop.close()
 
@@ -155,7 +155,7 @@ async def no_ssl_fake_async_home(fake_cloud, fake_connection_context_with_ssl, n
     home.init_with_context(fake_connection_context_with_ssl, use_rate_limiting=False)
     await home.get_current_state_async()
 
-    yield home
+    return home
 
 
 #

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -311,10 +311,10 @@ async def test_wait_for_websocket_connection_no_double_warning_when_threshold_eq
 async def test_wait_for_websocket_connection_rejects_non_positive_poll_interval(fake_home: Home):
     """poll_interval <= 0 is rejected up-front to avoid a hung coroutine."""
     with patch.object(fake_home, "websocket_is_connected", return_value=False), \
-         pytest.raises(ValueError):
+         pytest.raises(ValueError, match="poll_interval must be positive"):
         await fake_home.wait_for_websocket_connection_async(poll_interval=0)
     with patch.object(fake_home, "websocket_is_connected", return_value=False), \
-         pytest.raises(ValueError):
+         pytest.raises(ValueError, match="poll_interval must be positive"):
         await fake_home.wait_for_websocket_connection_async(poll_interval=-1)
 
 


### PR DESCRIPTION
## Summary

Tightens the linter to catch a handful of common issues. Most rules are added for enforcement only (zero existing violations); the rest produced ~22 mechanical fixes.

### New rule sets

- `ASYNC` — async correctness
- `A` — Python builtin shadowing
- `C4`, `ISC`, `TCH`, `TID` — already clean, added for enforcement going forward
- `PERF` — manual list-append loops
- `PT` — pytest style
- `RSE` — `raise X()` style

### Real fixes

See CHANGELOG entry. Highlights:

- `time.sleep` in async auth flow replaced with `await asyncio.sleep` (real bug).
- Internal builtin shadowing renamed where safe; one public-API parameter (`anonymizeConfig(format=...)`) kept with `# noqa: A002`.
- Three manual `list.append` loops → comprehensions / `list.extend`.

### Globally ignored

- `ASYNC109` (timeout parameter in async function): both call sites (`wait_for_websocket_connection_async`, `Buckets.wait_and_take`) are stable public API. Renaming the parameter would be breaking, and the existing names are semantically correct.

### Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest tests/` — 303/303 pass
- [x] No public API breakage (one keyword-argument call site updated: `set_attr_from_dict(... type=...)` → `enum_type=...`, internal callers only)