### PR TITLE
Register DEVICE_CODE_STATE_EVENT (HmIP-WKP) to silence Unknown EventType warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Register `DEVICE_CODE_STATE_EVENT` in the `EventType` enum so the websocket dispatcher recognizes the push event the HmIP-WKP keypad emits when a code is entered (payload: `codeIndex`, `codeState`). Previously this logged a "Unknown EventType" warning on every keypad press (fixes [#668](https://github.com/hahn-th/homematicip-rest-api/issues/668)). Full `codeState` handling (surfacing valid vs. unknown code as a typed event) will follow once all observed `codeState` values are documented.
+- Register `DEVICE_CODE_STATE_EVENT` in the `EventType` enum and forward it as a typed event to the originating device. Subscribe via `device.add_on_code_state_event_handler(handler)`; the handler receives a `CodeStateEvent` (`deviceId`, `codeIndex`, `codeState`). The HmIP-WKP keypad emits this event whenever a code is entered. Observed `codeState` values are `KNOWN_CODE_ID_RECEIVED` (valid code; `codeIndex` is the slot of the matched code) and `UNKNOWN_CODE_DETECTED` (wrong code). The raw string is forwarded so consumers can match any future codeState without further library changes. Previously the unknown event type logged a "Unknown EventType" warning on every keypad press (fixes [#668](https://github.com/hahn-th/homematicip-rest-api/issues/668)).
 
 ## [2.12.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.11.0..2.12.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED](https://github.com/hahn-th/homematicip-rest-api/compare/2.12.0..master)
 
+### Added
+
+- Register `DEVICE_CODE_STATE_EVENT` in the `EventType` enum so the websocket dispatcher recognizes the push event the HmIP-WKP keypad emits when a code is entered (payload: `codeIndex`, `codeState`). Previously this logged a "Unknown EventType" warning on every keypad press (fixes [#668](https://github.com/hahn-th/homematicip-rest-api/issues/668)). Full `codeState` handling (surfacing valid vs. unknown code as a typed event) will follow once all observed `codeState` values are documented.
+
 ## [2.12.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.11.0..2.12.0)
 
 ### Added

--- a/src/homematicip/async_home.py
+++ b/src/homematicip/async_home.py
@@ -7,6 +7,7 @@ import httpx
 
 from homematicip.access_point_update_state import AccessPointUpdateState
 from homematicip.base.channel_event import ChannelEvent
+from homematicip.base.code_state_event import CodeStateEvent
 from homematicip.class_maps import *
 from homematicip.client import Client
 from homematicip.connection.client_characteristics_builder import (
@@ -922,11 +923,15 @@ class AsyncHome(HomeMaticIPObject):
                         ch.fire_channel_event(channel_event)
                 elif pushEventType == EventType.DEVICE_CODE_STATE_EVENT:
                     # Emitted by HmIP-WKP (keypad) when a code is entered.
-                    # Payload: {"deviceId", "codeIndex", "codeState"}.
-                    # Registered to silence the "Unknown EventType" warning;
-                    # full codeState handling is a follow-up once all
-                    # codeState values are known.
-                    pass
+                    # Observed codeStates: "KNOWN_CODE_ID_RECEIVED" (valid),
+                    # "UNKNOWN_CODE_DETECTED" (wrong). The raw string is
+                    # forwarded so consumers can match any future state
+                    # without library changes.
+                    code_state_event = CodeStateEvent()
+                    code_state_event.from_json(event)
+                    device = self.search_device_by_id(code_state_event.deviceId)
+                    if device is not None:
+                        device.fire_code_state_event(code_state_event)
                 elif pushEventType == EventType.GROUP_REMOVED:
                     obj = self.search_group_by_id(event["id"])
                     obj.fire_remove_event(obj, event_type=pushEventType, obj=obj)

--- a/src/homematicip/async_home.py
+++ b/src/homematicip/async_home.py
@@ -920,6 +920,13 @@ class AsyncHome(HomeMaticIPObject):
                     ch = self.search_channel(channel_event.deviceId, channel_event.channelIndex)
                     if ch is not None:
                         ch.fire_channel_event(channel_event)
+                elif pushEventType == EventType.DEVICE_CODE_STATE_EVENT:
+                    # Emitted by HmIP-WKP (keypad) when a code is entered.
+                    # Payload: {"deviceId", "codeIndex", "codeState"}.
+                    # Registered to silence the "Unknown EventType" warning;
+                    # full codeState handling is a follow-up once all
+                    # codeState values are known.
+                    pass
                 elif pushEventType == EventType.GROUP_REMOVED:
                     obj = self.search_group_by_id(event["id"])
                     obj.fire_remove_event(obj, event_type=pushEventType, obj=obj)

--- a/src/homematicip/base/code_state_event.py
+++ b/src/homematicip/base/code_state_event.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+
+@dataclass()
+class CodeStateEvent:
+    """Class to hold a device code state event (HmIP-WKP keypad)."""
+
+    pushEventType: str | None = None
+    deviceId: str | None = None
+    codeIndex: int | None = None
+    codeState: str | None = None
+
+    def from_json(self, data: dict) -> None:
+        """Create a CodeStateEvent from a JSON dictionary."""
+        self.pushEventType = data.get("pushEventType")
+        self.deviceId = data.get("deviceId")
+        self.codeIndex = data.get("codeIndex")
+        self.codeState = data.get("codeState")
+
+    # {
+    #     "pushEventType": "DEVICE_CODE_STATE_EVENT",
+    #     "deviceId": "xxx",
+    #     "codeIndex": 1,
+    #     "codeState": "KNOWN_CODE_ID_RECEIVED",
+    # }

--- a/src/homematicip/base/enums.py
+++ b/src/homematicip/base/enums.py
@@ -408,6 +408,7 @@ class EventType(AutoNameEnum):
     DEVICE_CHANGED = auto()
     DEVICE_ADDED = auto()
     DEVICE_CHANNEL_EVENT = auto()
+    DEVICE_CODE_STATE_EVENT = auto()
     CLIENT_REMOVED = auto()
     CLIENT_CHANGED = auto()
     CLIENT_ADDED = auto()

--- a/src/homematicip/device.py
+++ b/src/homematicip/device.py
@@ -170,6 +170,8 @@ class Device(BaseDevice):
     def __init__(self, connection):
         super().__init__(connection)
 
+        self._on_code_state_event_handler = []
+
         self.liveUpdateState = None
         self.updateState = DeviceUpdateState.UP_TO_DATE
         self.availableFirmwareVersion = None
@@ -247,6 +249,19 @@ class Device(BaseDevice):
 
     def __str__(self):
         return f"{self.modelType} {self.label} {self.str_from_attr_map()}"
+
+    def add_on_code_state_event_handler(self, handler):
+        """Register a handler for code-state push events emitted by this device.
+
+        Fired with a :class:`CodeStateEvent` when the cloud reports
+        a ``DEVICE_CODE_STATE_EVENT`` for this device (HmIP-WKP keypad).
+        """
+        self._on_code_state_event_handler.append(handler)
+
+    def fire_code_state_event(self, *args, **kwargs):
+        """Invoke all registered code-state handlers."""
+        for _handler in self._on_code_state_event_handler:
+            _handler(*args, **kwargs)
 
     def set_label(self, label):
         return self._run_non_async(lambda: self.set_label_async(label))

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -11,6 +11,7 @@ from homematicip_demo.helper import (
 
 from conftest import utc_offset
 from homematicip.base.channel_event import ChannelEvent
+from homematicip.base.enums import EventType
 from homematicip.connection.connection_context import ConnectionContext
 from homematicip.device import BaseDevice, Device
 from homematicip.exceptions.connection_exceptions import (
@@ -1006,6 +1007,32 @@ async def test_websocket_channel_event(fake_home: Home):
     channel_event.from_json(payload["events"]["0"])
     fake_handler.assert_called_once_with(channel_event)
 
+
+async def test_websocket_device_code_state_event(fake_home: Home, caplog):
+    # HmIP-WKP emits this event when a code is entered. Verify it is
+    # recognized (no "Unknown EventType" warning) and that the event is
+    # forwarded via onEvent with the matching event type.
+    payload = {
+        "events":
+            {
+                "0":
+                    {
+                        "pushEventType": "DEVICE_CODE_STATE_EVENT",
+                        "deviceId": "3014F7110000000000WKP001",
+                        "codeIndex": 1,
+                        "codeState": "KNOWN_CODE_ID_RECEIVED",
+                    }
+            }
+    }
+    event_handler = Mock()
+    fake_home.onEvent += event_handler
+    with caplog.at_level("WARNING", logger="homematicip.async_home"):
+        await fake_home._ws_on_message(json.dumps(payload))
+
+    assert "Unknown EventType" not in caplog.text
+    event_handler.assert_called_once()
+    fired = event_handler.call_args.args[0]
+    assert fired[0]["eventType"] == EventType.DEVICE_CODE_STATE_EVENT
 
 
 @pytest.mark.asyncio

--- a/tests/test_home.py
+++ b/tests/test_home.py
@@ -11,6 +11,7 @@ from homematicip_demo.helper import (
 
 from conftest import utc_offset
 from homematicip.base.channel_event import ChannelEvent
+from homematicip.base.code_state_event import CodeStateEvent
 from homematicip.base.enums import EventType
 from homematicip.connection.connection_context import ConnectionContext
 from homematicip.device import BaseDevice, Device
@@ -1008,24 +1009,38 @@ async def test_websocket_channel_event(fake_home: Home):
     fake_handler.assert_called_once_with(channel_event)
 
 
-async def test_websocket_device_code_state_event(fake_home: Home, caplog):
+@pytest.mark.parametrize(
+    ("code_index", "code_state"),
+    [
+        (1, "KNOWN_CODE_ID_RECEIVED"),
+        (32, "UNKNOWN_CODE_DETECTED"),
+    ],
+)
+async def test_websocket_device_code_state_event(
+    fake_home: Home, caplog, code_index: int, code_state: str
+):
     # HmIP-WKP emits this event when a code is entered. Verify it is
-    # recognized (no "Unknown EventType" warning) and that the event is
-    # forwarded via onEvent with the matching event type.
+    # recognized (no "Unknown EventType" warning), forwarded via onEvent,
+    # and dispatched to the device's typed code-state handler with the
+    # raw codeState string preserved.
+    device_id = "3014F7110000RAIN_SENSOR"
     payload = {
         "events":
             {
                 "0":
                     {
                         "pushEventType": "DEVICE_CODE_STATE_EVENT",
-                        "deviceId": "3014F7110000000000WKP001",
-                        "codeIndex": 1,
-                        "codeState": "KNOWN_CODE_ID_RECEIVED",
+                        "deviceId": device_id,
+                        "codeIndex": code_index,
+                        "codeState": code_state,
                     }
             }
     }
     event_handler = Mock()
     fake_home.onEvent += event_handler
+    device_handler = Mock()
+    device = fake_home.search_device_by_id(device_id)
+    device.add_on_code_state_event_handler(device_handler)
     with caplog.at_level("WARNING", logger="homematicip.async_home"):
         await fake_home._ws_on_message(json.dumps(payload))
 
@@ -1033,6 +1048,14 @@ async def test_websocket_device_code_state_event(fake_home: Home, caplog):
     event_handler.assert_called_once()
     fired = event_handler.call_args.args[0]
     assert fired[0]["eventType"] == EventType.DEVICE_CODE_STATE_EVENT
+
+    expected = CodeStateEvent(
+        pushEventType="DEVICE_CODE_STATE_EVENT",
+        deviceId=device_id,
+        codeIndex=code_index,
+        codeState=code_state,
+    )
+    device_handler.assert_called_once_with(expected)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #668.

The HmIP-WKP keypad emits a `DEVICE_CODE_STATE_EVENT` push event whenever a code is entered. The library's `EventType` enum didn't list it, so the websocket dispatcher logged a "Unknown EventType" warning on every keypad press (payload: `{deviceId, codeIndex, codeState}`).

This PR:
- Adds `DEVICE_CODE_STATE_EVENT` to the `EventType` enum.
- Adds a `CodeStateEvent` dataclass mirroring `ChannelEvent`.
- Forwards the event as a typed device event: subscribe via `device.add_on_code_state_event_handler(handler)`; the handler receives a `CodeStateEvent` with the raw `codeIndex` and `codeState` from the cloud payload.
- Observed `codeState` values are `KNOWN_CODE_ID_RECEIVED` (valid code; `codeIndex` is the slot of the matched code) and `UNKNOWN_CODE_DETECTED` (wrong code; both reported by @LucTs on #668). The library does not enumerate `codeState` as an enum, so consumers can match any future state without library changes.
- Parametrized test covers both states, asserts dispatch to the per-device handler with the matching `CodeStateEvent`, and verifies no "Unknown EventType" warning is logged.