### PR TITLE
Lower default websocket_message_stale_timeout from 8h to 30min

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED](https://github.com/hahn-th/homematicip-rest-api/compare/2.13.0..master)
 
+### Changed
+
+- Lower default `websocket_message_stale_timeout` from 28800 s (8 h) to 1800 s (30 min). The websocket listen loop closes and reconnects when no message arrives within this window while the connection is reported open. The previous 8 h was a conservative last-resort safety net; in practice the websocket can stay healthy at the protocol layer while push events stop arriving, in which case devices appear unavailable until the safety net fires. The new default matches `STALE_ERROR_SECONDS`, the threshold at which the same condition is already reported via the `on_stale` callback. The previous value can be restored by passing `websocket_message_stale_timeout=28800` to `ConnectionContextBuilder.build_context_async` / `build_context`.
+
 ## [2.13.0](https://github.com/hahn-th/homematicip-rest-api/compare/2.12.0..2.13.0)
 
 ### Added

--- a/src/homematicip/connection/connection_context.py
+++ b/src/homematicip/connection/connection_context.py
@@ -21,7 +21,7 @@ class ConnectionContextBuilder:
                                   ssl_ctx=None,
                                   websocket_heartbeat_interval: int = 30,
                                   websocket_connect_timeout: int = 30,
-                                  websocket_message_stale_timeout: int = 28800,
+                                  websocket_message_stale_timeout: int = 1800,
                                   websocket_initial_backoff: int = 8,
                                   websocket_max_backoff: int = 900):
         """
@@ -63,7 +63,7 @@ class ConnectionContextBuilder:
                       ssl_ctx: SSLContext | str | bool | None = None,
                       websocket_heartbeat_interval: int = 30,
                       websocket_connect_timeout: int = 30,
-                      websocket_message_stale_timeout: int = 28800,
+                      websocket_message_stale_timeout: int = 1800,
                       websocket_initial_backoff: int = 8,
                       websocket_max_backoff: int = 900):
         """
@@ -109,6 +109,6 @@ class ConnectionContext:
     ssl_ctx: SSLContext | str | bool | None = None
     websocket_heartbeat_interval: int = 30
     websocket_connect_timeout: int = 30
-    websocket_message_stale_timeout: int = 28800
+    websocket_message_stale_timeout: int = 1800
     websocket_initial_backoff: int = 8
     websocket_max_backoff: int = 900

--- a/tests/connection/test_connection_context.py
+++ b/tests/connection/test_connection_context.py
@@ -47,6 +47,30 @@ async def test_build_context_without_client_session(mocker):
 
 
 @pytest.mark.asyncio
+async def test_build_context_websocket_settings_defaults(mocker):
+    response = mocker.Mock(spec=httpx.Response)
+    response.status_code = 200
+    response.json.return_value = {
+        "urlREST": "https://example.com/rest",
+        "urlWebSocket": "wss://example.com/ws",
+    }
+
+    patched = mocker.patch("homematicip.connection.connection_context.httpx.AsyncClient.post")
+    patched.return_value = response
+
+    context = await ConnectionContextBuilder.build_context_async(
+        "access_point_id",
+        "https://example.com/lookup",
+    )
+
+    assert context.websocket_heartbeat_interval == 30
+    assert context.websocket_connect_timeout == 30
+    assert context.websocket_message_stale_timeout == 1800
+    assert context.websocket_initial_backoff == 8
+    assert context.websocket_max_backoff == 900
+
+
+@pytest.mark.asyncio
 async def test_build_context_carries_websocket_settings(mocker):
     response = mocker.Mock(spec=httpx.Response)
     response.status_code = 200


### PR DESCRIPTION
The websocket listen loop closes and reconnects when no message arrives within `websocket_message_stale_timeout` while the connection is reported open. The 8 h default was set as a last-resort safety net under the assumption that the aiohttp heartbeat (~30 s) catches every dead connection.

In practice the HomematicIP Cloud occasionally keeps the websocket layer healthy (ping/pong continues) while silently stopping push events. Example from a production HA setup running `homematicip 2.13.0`:

```
22:26:36 ERROR   websocket_handler: Error in websocket: ServerTimeoutError('No PONG received after 15.0 seconds')
22:26:36 INFO    Connect to wss://srv5001.a.homematic.com:8888
22:26:36 INFO    WebSocket connection established
... no events for 8 h, devices stuck unavailable on the consumer side ...
06:26:37 WARNING websocket_handler: No HomematicIP websocket events received for 28800 seconds despite an open connection. Forcing reconnect as a stale-connection safety net.
06:26:37 INFO    Updating state after HMIP access point reconnect finished successfully
```

The new 1800 s default matches `STALE_ERROR_SECONDS`, the threshold at which the same condition is already surfaced via the `on_stale` callback. Aligning the safety-net reconnect with that threshold keeps the staleness timeline internally consistent.

The previous behavior can be restored by passing `websocket_message_stale_timeout=28800` to `ConnectionContextBuilder.build_context_async` / `build_context`.

### Tests

- New `test_build_context_websocket_settings_defaults` confirms the new default.
- Existing `test_build_context_carries_websocket_settings` continues to confirm explicit overrides work unchanged.