### PR TITLE
Re-resolve websocket host after repeated connect failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [UNRELEASED](https://github.com/hahn-th/homematicip-rest-api/compare/2.13.1..master)
 
+### Fixed
+
+- Re-resolve the cloud host after repeated websocket connect failures. The reconnect loop retried the same cached host indefinitely, so when the assigned host went down (returning HTTP 502 on every connect) the connection never recovered even though a fresh lookup would have returned a healthy host. After `WebsocketHandler.RELOOKUP_AFTER_ATTEMPTS` consecutive failures (default 3) the handler now performs a new host lookup before the next attempt. Short outages still recover via cheap same-host retries first; a failing lookup falls back to the current host.
+
 ## [2.13.1](https://github.com/hahn-th/homematicip-rest-api/compare/2.13.0..2.13.1)
 
 ### Changed

--- a/src/homematicip/connection/websocket_handler.py
+++ b/src/homematicip/connection/websocket_handler.py
@@ -13,7 +13,10 @@ from homematicip.connection import (
     ATTR_AUTH_TOKEN,
     ATTR_CLIENT_AUTH,
 )
-from homematicip.connection.connection_context import ConnectionContext
+from homematicip.connection.connection_context import (
+    ConnectionContext,
+    ConnectionContextBuilder,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -30,6 +33,10 @@ class WebsocketHandler:
         self.HEARTBEAT_INTERVAL = 30
         self.CONNECT_TIMEOUT = 30
         self.MESSAGE_STALE_TIMEOUT = 28800
+        # Re-resolve the cloud host after this many consecutive connect
+        # failures. The reconnect loop otherwise retries the same cached host
+        # forever, which never recovers when that host stays down (HTTP 502).
+        self.RELOOKUP_AFTER_ATTEMPTS = 3
         # Staleness early-warning thresholds. The MESSAGE_STALE_TIMEOUT
         # safety net only forces a reconnect after 8h; these fire much
         # earlier so consumers can surface the condition to users.
@@ -127,6 +134,8 @@ class WebsocketHandler:
         backoff = self.INITIAL_BACKOFF
         while not self._stop_event.is_set():
             try:
+                if self._reconnect_attempt_count >= self.RELOOKUP_AFTER_ATTEMPTS:
+                    context = await self._relookup_context(context)
                 LOGGER.info("Connect to %s", context.websocket_url)
 
                 async with aiohttp.ClientSession() as session:
@@ -175,6 +184,25 @@ class WebsocketHandler:
             finally:
                 await self._cleanup()
 
+    async def _relookup_context(self, context: ConnectionContext) -> ConnectionContext:
+        try:
+            refreshed = await ConnectionContextBuilder.build_context_async(
+                accesspoint_id=context.accesspoint_id,
+                auth_token=context.auth_token,
+                enforce_ssl=context.enforce_ssl,
+                ssl_ctx=context.ssl_ctx,
+                websocket_heartbeat_interval=context.websocket_heartbeat_interval,
+                websocket_connect_timeout=context.websocket_connect_timeout,
+                websocket_message_stale_timeout=context.websocket_message_stale_timeout,
+                websocket_initial_backoff=context.websocket_initial_backoff,
+                websocket_max_backoff=context.websocket_max_backoff,
+            )
+        except Exception:
+            LOGGER.exception("Re-lookup of websocket host failed, keeping current host")
+            return context
+        if refreshed.websocket_url != context.websocket_url:
+            LOGGER.info("Re-resolved websocket host to %s", refreshed.websocket_url)
+        return refreshed
 
     async def _listen(self, ws):
         while not self._stop_event.is_set():

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -306,6 +306,70 @@ async def test_connect_passes_ssl_ctx_when_provided(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_connect_relookups_host_after_repeated_failures(monkeypatch):
+    """After RELOOKUP_AFTER_ATTEMPTS consecutive failures the handler re-resolves
+    the cloud host and connects to the freshly looked-up url instead of retrying
+    the dead one forever."""
+    client = WebsocketHandler()
+    client.INITIAL_BACKOFF = 0
+    client.RELOOKUP_AFTER_ATTEMPTS = 2
+    tried = []
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def ws_connect(self, url, **kwargs):
+            tried.append(url)
+            if url == "wss://healthy.invalid/ws":
+                client._stop_event.set()
+            raise TimeoutError("dead host")
+
+    monkeypatch.setattr(
+        "homematicip.connection.websocket_handler.aiohttp.ClientSession",
+        FakeSession,
+    )
+
+    fresh = MagicMock()
+    fresh.websocket_url = "wss://healthy.invalid/ws"
+    build_mock = AsyncMock(return_value=fresh)
+    monkeypatch.setattr(
+        "homematicip.connection.websocket_handler.ConnectionContextBuilder.build_context_async",
+        build_mock,
+    )
+
+    context = MagicMock()
+    context.websocket_url = "wss://dead.invalid/ws"
+    context.accesspoint_id = "a"
+
+    await client._connect(context)
+
+    build_mock.assert_awaited()
+    assert tried[:2] == ["wss://dead.invalid/ws", "wss://dead.invalid/ws"]
+    assert "wss://healthy.invalid/ws" in tried
+
+
+@pytest.mark.asyncio
+async def test_relookup_context_falls_back_on_error(monkeypatch):
+    """A failing re-lookup keeps the current context instead of raising."""
+    client = WebsocketHandler()
+    monkeypatch.setattr(
+        "homematicip.connection.websocket_handler.ConnectionContextBuilder.build_context_async",
+        AsyncMock(side_effect=Exception("lookup down")),
+    )
+
+    context = MagicMock()
+    context.websocket_url = "wss://dead.invalid/ws"
+
+    result = await client._relookup_context(context)
+
+    assert result is context
+
+
+@pytest.mark.asyncio
 async def test_add_on_stale_handler_registers():
     client = WebsocketHandler()
     handler = MagicMock()


### PR DESCRIPTION
## Problem
When the cloud host assigned at setup goes down and returns HTTP 502 on every
websocket connect, the reconnect loop retries that same cached host forever
(observed: 117 attempts over ~4.5h, all 502). Devices stay frozen on their last
state. A fresh host lookup (what the app does on each launch, or an integration
reload) lands on a healthy host and recovers immediately.

## Fix
After `WebsocketHandler.RELOOKUP_AFTER_ATTEMPTS` consecutive connect failures
(default 3), re-resolve the host via `ConnectionContextBuilder` before the next
attempt. Short outages still recover via cheap same-host retries first; a
failing lookup falls back to the current host.

## Tests
- `test_connect_relookups_host_after_repeated_failures`
- `test_relookup_context_falls_back_on_error`